### PR TITLE
simplify proof of TW2_of_K4F

### DIFF
--- a/theories/minor.v
+++ b/theories/minor.v
@@ -67,6 +67,13 @@ Proof.
     apply/neighborP; exists x'; exists y'. by rewrite add_edgeC.
 Qed.
 
+Lemma rmap_disjE (G H : sgraph) (phi : H -> {set G}) x i j :
+  minor_rmap phi -> x \in phi i -> x \in phi j -> i=j.
+Proof.
+  move => [_ _ map _] xi. apply contraTeq => iNj. 
+  by erewrite (disjointFr (map _ _ iNj)).
+Qed.
+
 Definition minor (G H : sgraph) : Prop := exists phi : G -> option H, minor_map phi.
 
 Fact minor_of_map (G H : sgraph) (phi : G -> option H): 
@@ -195,8 +202,28 @@ Proof.
     split=> //. exact: hH.
 Qed.
 
-Lemma induced_minor (G : sgraph) (S : {set G}) : minor G (induced S).
-Proof. apply: sub_minor. exact: induced_sub. Qed.
+(** Induced subgraphs are trivially minors *)
+Section induced_rmap.
+Variables (G : sgraph) (S : {set G}).
+
+Definition induced_rmap := (fun x : induced S => [set val x]).
+
+Lemma induced_rmapP : minor_rmap induced_rmap.
+Proof.
+split.
+- move=> ?; exact: set10.
+- move=> ?; exact: connected1.
+- by move=> ? ?; rewrite disjoints1 inE val_eqE.
+- by move=> ? ?; rewrite neighbor11.
+Qed.
+
+Lemma induced_rmap_sub u : induced_rmap u \subset S.
+Proof. by rewrite /induced_rmap sub1set; apply: (valP u). Qed.
+
+Lemma induced_minor : minor G (induced S).
+Proof. exact: minor_of_rmap induced_rmapP. Qed.
+
+End induced_rmap.
 
 Definition edge_surjective (G1 G2 : sgraph) (h : G1 -> G2) :=
   forall x y : G2 , x -- y -> exists x0 y0, [/\ h x0 = x, h y0 = y & x0 -- y0].

--- a/theories/sgraph.v
+++ b/theories/sgraph.v
@@ -1287,6 +1287,12 @@ Section Neighbor.
   Lemma neighborUr A B C : neighbor A C -> neighbor A (B :|: C).
   Proof. apply: neighborW => //. exact: subsetUr. Qed.
 
+  Lemma neighbor11 x y: neighbor [set x] [set y] = x -- y.
+  Proof.
+    apply/neighborP/idP => [[?[?[/set1P -> /set1P ->]]] //|xy].
+    by exists x,y; rewrite !inE eqxx.
+  Qed.
+
 End Neighbor.
 Arguments neighborW : clear implicits.
 


### PR DESCRIPTION
This PR (significantly) simplifies the construction of tree decompositions for K_4-free graphs by exploiting that for any graph `G` with a proper separation `V1,V2` extending a minimal separator `{x,y}` (with `x != y`) any minor of the subgraphs induced by `V1` and `V2` in `add_edge G x y` is also a minor of `G`. 

The proof of ` TW2_of_K4F` is changed to no longer rely on `K4_free_add_edge_sep_size2`, and the proof of the latter is drastically simplified by relying on the observation above. 

Due `TW2_of_K4F` no longer relying on `K4_free_add_edge_sep_size2`, we could remove the latter (and `separation_K4side`). 