### PR TITLE
Wagner's theorem (main direction)

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -1,5 +1,3 @@
-# This file was generated from `meta.yml`, please do not edit manually.
-# Follow the instructions on https://github.com/coq-community/templates to regenerate.
 name: Docker CI
 
 on:
@@ -29,6 +27,15 @@ jobs:
         with:
           opam_file: 'coq-graph-theory.opam'
           custom_image: ${{ matrix.image }}
+          # we manually install the optional dependency coq-fourcolor
+          install: |
+            startGroup "Install dependencies"
+              opam pin add -n -y -k path $PACKAGE $WORKDIR
+              opam update -y
+              opam install -y -j 2 $PACKAGE --deps-only
+              opam install -y -j 2 coq-fourcolor
+            endGroup
+
 
 # See also:
 # https://github.com/coq-community/docker-coq-action#readme

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ isomorphism).
   - MathComp's SSReflect library, version 1.12 or later
   - MathComp's finmap library
   - Hierarchy Builder, version 1.0.0 or later
+  - Gonthier's Formal Proof of the Four-Color Theorem
 - Coq namespace: `GraphTheory`
 - Related publication(s):
   - [Graph Theory in Coq - Minors, Treewidth, and Isomorphisms](https://hal.archives-ouvertes.fr/hal-02316859) doi:[10.1007/s10817-020-09543-2](https://doi.org/10.1007/s10817-020-09543-2)

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ isomorphism).
 - License: [CeCILL-B](LICENSE)
 - Compatible Coq versions: 8.12 or later
 - Additional dependencies:
-  - MathComp's SSReflect library, version 1.12 or later
+  - MathComp's Algebra library, version 1.12 or later
   - MathComp's finmap library
   - Hierarchy Builder, version 1.0.0 or later
-  - Gonthier's Formal Proof of the Four-Color Theorem
+  - Gonthier's Formal Proof of the Four-Color Theorem (optional)
 - Coq namespace: `GraphTheory`
 - Related publication(s):
   - [Graph Theory in Coq - Minors, Treewidth, and Isomorphisms](https://hal.archives-ouvertes.fr/hal-02316859) doi:[10.1007/s10817-020-09543-2](https://doi.org/10.1007/s10817-020-09543-2)

--- a/_CoqProject
+++ b/_CoqProject
@@ -29,7 +29,7 @@ theories/minor.v
 theories/excluded.v
 theories/checkpoint.v
 theories/cp_minor.v
-theories/smerge.v
+theories/smerge.v #(ITP 21)
 
 ## soundness and completeness for 2pdom (CPP20)
 theories/structures.v
@@ -58,7 +58,7 @@ theories/partition.v
 theories/coloring.v
 theories/wpgt.v
 
-## Kuratowsi's/Wagner's theorem
+## Kuratowsi's/Wagner's theorem (ITP 21)
 theories/hmap_ops.v
 theories/hcycle.v
 theories/embedding.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -57,10 +57,3 @@ theories/dom.v
 theories/partition.v
 theories/coloring.v
 theories/wpgt.v
-
-## Kuratowsi's/Wagner's theorem (ITP 21)
-theories/hmap_ops.v
-theories/hcycle.v
-theories/embedding.v
-theories/K4plane.v
-theories/wagner.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -3,6 +3,8 @@
 -arg -w -arg -projection-no-head-constant
 -arg -w -arg -duplicate-clear
 -arg -w -arg -elpi.add-const-for-axiom-or-sectionvar
+-arg -w -arg -ambiguous-paths
+
 -R theories GraphTheory
 
 ## preliminary modules
@@ -55,3 +57,10 @@ theories/dom.v
 theories/partition.v
 theories/coloring.v
 theories/wpgt.v
+
+## Kuratowsi's/Wagner's theorem
+theories/hmap_ops.v
+theories/hcycle.v
+theories/embedding.v
+theories/K4plane.v
+theories/wagner.v

--- a/_CoqProject.wagner
+++ b/_CoqProject.wagner
@@ -1,0 +1,6 @@
+## Kuratowsi's/Wagner's theorem (ITP 21)
+theories/hmap_ops.v
+theories/hcycle.v
+theories/embedding.v
+theories/K4plane.v
+theories/wagner.v

--- a/coq-graph-theory.opam
+++ b/coq-graph-theory.opam
@@ -20,15 +20,18 @@ from the study of relation algebra within the ERC CoVeCe project
 (e.g., soundness and completeness of an axiomatization of graph
 isomorphism)."""
 
-build: [make "-j%{jobs}%" ]
+build: [
+  ["sh" "-exc" "cat _CoqProject.wagner >>_CoqProject"] {coq-fourcolor:installed}
+  [make "-j%{jobs}%" ]
+]
 install: [make "install"]
 depends: [
   "coq" {(>= "8.12" & < "8.14~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.13~") | (= "dev")}
+  "coq-mathcomp-algebra" {(>= "1.12" & < "1.13~") | (= "dev")}
   "coq-mathcomp-finmap" 
   "coq-hierarchy-builder" { (>= "1.1.0") }
-  "coq-fourcolor" 
 ]
+depopts: ["coq-fourcolor"]
 
 tags: [
   "category:Computer Science/Graph Theory"

--- a/coq-graph-theory.opam
+++ b/coq-graph-theory.opam
@@ -27,6 +27,7 @@ depends: [
   "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.13~") | (= "dev")}
   "coq-mathcomp-finmap" 
   "coq-hierarchy-builder" { (>= "1.1.0") }
+  "coq-fourcolor" 
 ]
 
 tags: [

--- a/depopts.patch
+++ b/depopts.patch
@@ -1,0 +1,25 @@
+diff --git a/coq-graph-theory.opam b/coq-graph-theory.opam
+index 2a9ea1d..8487df7 100644
+--- a/coq-graph-theory.opam
++++ b/coq-graph-theory.opam
+@@ -20,15 +20,18 @@ from the study of relation algebra within the ERC CoVeCe project
+ (e.g., soundness and completeness of an axiomatization of graph
+ isomorphism)."""
+ 
+-build: [make "-j%{jobs}%" ]
++build: [
++  ["sh" "-exc" "cat _CoqProject.wagner >>_CoqProject"] {coq-fourcolor:installed}
++  [make "-j%{jobs}%" ]
++]
+ install: [make "install"]
+ depends: [
+   "coq" {(>= "8.12" & < "8.14~") | (= "dev")}
+   "coq-mathcomp-algebra" {(>= "1.12" & < "1.13~") | (= "dev")}
+   "coq-mathcomp-finmap" 
+   "coq-hierarchy-builder" { (>= "1.1.0") }
+-  "coq-fourcolor" 
+ ]
++depopts: ["coq-fourcolor"]
+ 
+ tags: [
+   "category:Computer Science/Graph Theory"

--- a/meta.yml
+++ b/meta.yml
@@ -82,6 +82,9 @@ dependencies:
     name: coq-hierarchy-builder
     version: '{ (>= "1.1.0") }'
   description: Hierarchy Builder, version 1.0.0 or later
+- opam:
+    name: coq-fourcolor
+  description: Gonthier's Formal Proof of the Four-Color Theorem
 
 namespace: GraphTheory
 

--- a/meta.yml
+++ b/meta.yml
@@ -72,9 +72,9 @@ ci_cron_schedule: '25 5 * * *'
 
 dependencies:
 - opam:
-    name: coq-mathcomp-ssreflect
+    name: coq-mathcomp-algebra
     version: '{(>= "1.12" & < "1.13~") | (= "dev")}'
-  description: MathComp's SSReflect library, version 1.12 or later
+  description: MathComp's Algebra library, version 1.12 or later
 - opam:
     name: coq-mathcomp-finmap
   description: MathComp's finmap library
@@ -84,7 +84,7 @@ dependencies:
   description: Hierarchy Builder, version 1.0.0 or later
 - opam:
     name: coq-fourcolor
-  description: Gonthier's Formal Proof of the Four-Color Theorem
+  description: Gonthier's Formal Proof of the Four-Color Theorem (optional)
 
 namespace: GraphTheory
 

--- a/theories/K4plane.v
+++ b/theories/K4plane.v
@@ -1,0 +1,294 @@
+From mathcomp Require Import all_ssreflect.
+From fourcolor Require Import hypermap geometry.
+Require Import preliminaries digraph sgraph hmap_ops embedding.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Lemma order_max (T : finType) (f : T -> T) (x : T) : order f x <= #|T|.
+Proof. by rewrite -size_orbit -(card_uniqP _) ?max_card ?orbit_uniq. Qed.
+
+
+
+Section Dfs.
+Variables (T : finType) (g : T -> seq T).
+
+(* not used *)
+Lemma dfs_uniq  (v : seq T) x n : 
+  uniq v -> uniq (dfs g n v x).
+Proof.
+elim: n v x => [|/= n IHn] v x uniq_v ; first by rewrite /= if_same.
+have [//|xNv] := boolP (x \in v).
+have: uniq (x::v) by rewrite /= xNv.
+elim: (g x) (x::v) => //= => {v x uniq_v xNv} y gx IHgx v uniq_v.
+exact/IHgx/IHn.
+Qed.
+
+Lemma dfs_start x : x \in dfs g #|T| [::] x.
+Proof. by apply/dfsP; exists [::]. Qed.
+
+(** To actually run [dfs] we need to have [#|T|] as an explicit number *)
+Variable k : nat.
+Hypothesis kT : k = #|T|.
+
+Definition connect_dfs x := dfs g k [::] x.
+
+Lemma connectEdfs x : connect (grel g) x =i connect_dfs x.
+Proof. by move=> y;rewrite /connect_dfs kT; apply/connectP/dfsP. Qed.
+
+Fixpoint n_comp_dfs_rec n (s: seq T) :=
+  if n isn't n'.+1 then 0 else
+  if s is y::s' then
+    let p := connect_dfs y in 
+    (n_comp_dfs_rec n' (filter [predC p] s')).+1 else 0.
+
+Definition n_comp_dfs s := n_comp_dfs_rec (size s) s.
+
+Lemma n_comp_dfsP (s: seq T) : 
+  connect_sym (grel g) -> closed (grel g) s -> n_comp (grel g) s = n_comp_dfs s.
+Proof.
+move=> csym_g; rewrite /n_comp_dfs; move: {-1}(size s) (leqnn (size s)) => n.
+have [m Hm] := ubnP (size s); elim: m s Hm n => // m IH [_|y s /ltnSE Hm [//|n]].
+  by move => n _ _; rewrite n_comp0 //; case: n.
+move=> leq_s_n closed_y; set p := connect_dfs y.
+have y_p : y \in p by rewrite /p/connect_dfs kT; exact: dfs_start. 
+have Hp : p =i connect (grel g) y by move => ?; apply/esym/connectEdfs.
+have sub_p : {subset p <= y::s}.
+{ move=> z; rewrite Hp inE => con_yz. 
+  by rewrite -(closed_connect closed_y con_yz) mem_head. }
+rewrite (n_compD (mem p)) [RHS]/= -/p -add1n; congr(_ + _).
+- suff S : [predI y :: s & mem p] =i connect (grel g) y.
+    by rewrite (eq_n_comp_r S) n_comp_connect.
+  by move=> z; rewrite -[RHS]Hp inE /= andb_idl//; exact: sub_p.
+- rewrite -IH.
+  + apply: eq_n_comp_r => z; rewrite mem_filter !inE.
+    have [//|zNp/=] := boolP (z \in p); rewrite (_ : z == y = false) //.
+    by apply: contraNF zNp => /eqP->. 
+  + by apply: leq_trans Hm; rewrite size_filter /= ltnS count_size.
+  + rewrite /= ltnS in leq_s_n. apply: leq_trans leq_s_n. 
+    by rewrite size_filter count_size.
+  + have -> : [seq x <- s | [predC p] x] = [seq x <- y::s | [predC p] x].
+      by rewrite /= y_p.
+    have i : [seq x <- y :: s | [predC p] x] =i [predD (y :: s) & p].
+      by move=> z; rewrite mem_filter /= !inE. 
+    rewrite (eq_closed_r i); apply: predD_closed => //.
+    by rewrite (eq_closed_r Hp); apply: connect_closed.
+Qed.
+
+End Dfs.
+
+(** TODO: this uses nothing that is specific to ['I_n], all we use is
+that [#|'I_n| = n] and that we habe a concrete enumeration, i.e., one
+where all elements of the list are of the form [Ordinal n (isT : _)].
+Hence, it would be preferrabe to introduce a class or structure for
+this. *)
+
+Section ComputeOrd.
+Variable (n : nat).
+
+Definition ord_enum_eq : seq 'I_n := pmap (insub_eq _) (iota 0 n).
+
+Lemma eq_ord_enum : ord_enum_eq = ord_enum n.
+Proof. apply:eq_in_pmap => k _. exact: insub_eqE. Qed.
+
+Lemma ord_enum_eqT : ord_enum_eq =i 'I_n.
+Proof. by move => i; rewrite eq_ord_enum mem_ord_enum. Qed.
+
+Lemma forall_all_ord (p : {pred 'I_n}) : 
+  [forall x : 'I_n, p x] = all p ord_enum_eq.
+Proof. 
+by rewrite forall_all; apply/eq_all_r => x; rewrite mem_enum ord_enum_eqT. 
+Qed.
+
+Lemma exists_has_ord (p : {pred 'I_n}) : 
+  [exists x : 'I_n, p x] = has p ord_enum_eq.
+Proof. 
+by rewrite exists_has ; apply/eq_has_r => x; rewrite mem_enum ord_enum_eqT. 
+Qed.
+
+Implicit Types (e: rel 'I_n) (f : 'I_n -> 'I_n) (x : 'I_n).
+
+Definition sseq e x := [seq y <- ord_enum_eq | e x y].
+
+Let eq_sseq e : e =2 grel (sseq e).
+Proof.
+by move=> x y /=; rewrite mem_filter eq_ord_enum mem_ord_enum andbT.
+Qed.
+
+Definition n_comp_ord e (s : seq 'I_n)  := n_comp_dfs (sseq e) n s.
+
+Lemma n_compEord_seq e (s : seq 'I_n) (a : {pred 'I_n}) : 
+  connect_sym e -> closed e a -> s =i a -> n_comp e a = n_comp_ord e s.
+Proof.
+move=> sym_e cl_a eq_a_s; rewrite -(eq_n_comp_r eq_a_s).
+rewrite (eq_n_comp (eq_connect (eq_sseq e))). 
+apply: n_comp_dfsP; rewrite ?card_ord //.
+  exact: eq_connect_sym sym_e.
+by rewrite -(eq_closed (eq_sseq e)) (eq_closed_r eq_a_s).
+Qed.
+
+Definition order_ord f x := size (undup (traject f x n)).
+
+Lemma orderEord f x : order f x = order_ord f x.
+Abort.
+
+Definition orbit_ord f x := traject f x (order_ord f x).
+
+Lemma orbitEord f x : orbit f x = orbit_ord f x.
+(* Proof. by rewrite /orbit_ord -orderEord. Qed. *)
+Abort.
+
+Definition connect_ord (e : rel 'I_n) x y := y \in dfs (sseq e) n [::] x.
+
+Lemma connectEord (e : rel 'I_n) : connect e =2 connect_ord e.
+Proof. 
+move => x y; rewrite (eq_connect (eq_sseq e)); apply: connectEdfs.
+by rewrite card_ord.
+Qed.
+
+Definition fcard_ord f := n_comp_dfs (fun x => [:: f x]) n ord_enum_eq.
+
+Lemma n_compEord e : 
+  connect_sym e -> n_comp e 'I_n = n_comp_ord e (ord_enum_eq).
+Proof. move=> sym_s; exact: n_compEord_seq ord_enum_eqT. Qed.
+
+(** we don't use [n_compEord_seq], because doing so would require
+proving extensionality of [dfs] and the SCC algorithm *)
+Lemma fcardEord f : injective f -> fcard f 'I_n = fcard_ord f.
+Proof. 
+have eq_f : frel f =2 grel (fun x => [:: f x]).
+  by move => u v; rewrite /= !inE eq_sym.
+move=> inj_f; rewrite (eq_n_comp (eq_connect eq_f)).
+rewrite -(eq_n_comp_r ord_enum_eqT).
+rewrite (n_comp_dfsP (k := n)) ?card_ord //.
+- apply: eq_connect_sym eq_f _. exact: fconnect_sym. 
+- move => x y. by rewrite !ord_enum_eqT.
+Qed.
+
+End ComputeOrd.
+
+Section D4.
+
+Definition n := 12.
+Notation "''d' m" := (@Ordinal n m is_true_true) (at level 0, m at level 8, format "''d' m").
+
+Definition D4_edge (x : 'I_n) : 'I_n :=
+  match val x with
+    | 0 => 'd4
+    | 1 => 'd7
+    | 2 => 'd10
+    | 3 => 'd8
+    | 4 => 'd0
+    | 5 => 'd9
+    | 6 => 'd11
+    | 7 => 'd1
+    | 8 => 'd3
+    | 9 => 'd5
+    | 10 => 'd2
+    | 11 => 'd6
+    | _ => 'd0
+  end.
+
+Definition D4_node (x : 'I_n) : 'I_n :=
+  match val x with
+  | 0 => 'd1
+  | 1 => 'd2
+  | 2 => 'd0
+  | 3 => 'd4
+  | 4 => 'd5
+  | 5 => 'd3
+  | 6 => 'd7
+  | 7 => 'd8
+  | 8 => 'd6
+  | 9 => 'd10
+  | 10 => 'd11
+  | 11 => 'd9
+  | _ => 'd0
+  end.
+
+Definition D4_face (x : 'I_n) : 'I_n := 
+  match val x with
+  | 0 => 'd3
+  | 1 => 'd6
+  | 2 => 'd9
+  | 3 => 'd7
+  | 4 => 'd2
+  | 5 => 'd11
+  | 6 => 'd10
+  | 7 => 'd0
+  | 8 => 'd5
+  | 9 => 'd4
+  | 10 => 'd1
+  | 11 => 'd8
+  | _ => 'd0
+  end.
+
+
+Lemma D4can : cancel3 D4_edge D4_node D4_face.
+Proof. 
+move=>x; apply/eqP; move: x; apply/forallP.
+by rewrite forall_all_ord.
+Qed.
+
+Definition D4 := Hypermap D4can.
+
+Lemma D4_planar : planar D4.
+Proof. 
+rewrite /planar/genus/Euler_lhs/Euler_rhs. 
+rewrite (n_compEord (@glinkC D4)) (fcardEord (@faceI D4)).
+by rewrite (fcardEord (@edgeI D4)) (fcardEord (@nodeI D4)) card_ord.
+Qed.
+
+Lemma D4_plain : plain D4.
+Proof. 
+apply/plainP => x _; rewrite (rwP eqP) (rwP andP); move: x.
+by apply/forallP; rewrite forall_all_ord. 
+Qed.
+
+Definition D4_g (x : D4) : 'K_4 := 
+  match val x with
+  | 0 => ord0
+  | 1 => ord0
+  | 2 => ord0
+  | 3 => ord1
+  | 4 => ord1 
+  | 5 => ord1
+  | 6 => ord2
+  | 7 => ord2
+  | 8 => ord2
+  | 9 => ord3
+  | 10 => ord3
+  | 11 => ord3
+  | _ => ord0
+  end.
+
+
+Lemma D4_embedding : embedding D4_g.
+Proof.
+split; first exact D4_plain.
+- move=> x. apply/codomP. setoid_rewrite (rwP eqP). apply/existsP; rewrite exists_has_ord. 
+  move: x. apply/forallP. rewrite forall_all_ord. reflexivity.
+- move => x y. rewrite connectEord (rwP eqP). 
+  move: y; apply/forallP; rewrite forall_all_ord.
+  move: x; apply/forallP; rewrite forall_all_ord. reflexivity.
+- move => x y. rewrite /adjn; under eq_existsb => z do rewrite !inE !connectEord.
+  rewrite exists_has_ord (rwP eqP).
+  move: y; apply/forallP; rewrite forall_all_ord.
+  move: x; apply/forallP; rewrite forall_all_ord. reflexivity.
+Qed.
+
+Definition K4_plane_emb := Build_plane_embedding D4_embedding D4_planar.
+
+End D4.
+
+(** Any subgraph of K4 is planar as well *)
+Lemma small_planar (G : sgraph) : 
+  #|G| <= 4 -> no_isolated G -> inhabited (plane_embedding G).
+Proof.
+move=> smallG no_isoG.
+exact: subgraph_plane_embedding (sub_Kn smallG) no_isoG K4_plane_emb.
+Qed.
+
+
+

--- a/theories/embedding.v
+++ b/theories/embedding.v
@@ -1,0 +1,1445 @@
+From mathcomp Require Import all_ssreflect.
+From fourcolor Require Import hypermap geometry color coloring walkup combinatorial4ct cfmap.
+Require Import edone preliminaries bij digraph sgraph connectivity minor hmap_ops smerge hcycle arc.
+
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Set Bullet Behavior "Strict Subproofs".
+
+Lemma predIT (T : eqType) (A B : pred T) : B =1 predT -> predI A B =i A.
+Proof. move => BT x. by rewrite !inE BT /= andbT. Qed.
+Arguments predIT [T A B].
+
+Lemma plain_face (D : hypermap) (x : D) :
+  plain D -> face x = finv node (edge x).
+Proof. by move=> plainD; rewrite -plain_eq' // finv_f. Qed.
+
+(** * Hypermaps as embeddings of (planar) grahs *)
+
+(** This is mainly usedful when takling about embeddings, as hypermaps
+cannot represent isolated vertices. *)
+Definition no_isolated (G : sgraph) := forall x : G, exists y : G, x -- y.
+
+Lemma add_edge_no_isolated (G : sgraph) (x y : G) :
+  no_isolated G -> no_isolated (add_edge x y).
+Proof.
+by move => no_isoG u; have [v uv] := no_isoG u; exists v; rewrite /edge_rel/= uv.
+Qed.
+
+(** In this file we define what it means for a hypermap to represent a simple graph. *)
+
+Record embedding (G : sgraph) (D : hypermap) (f : D -> G) := 
+  Embedding { 
+      emb_plain : plain D;
+      emb_surj x : x \in codom f;
+      emb_vertex d1 d2 : cnode d1 d2 = (f d1 == f d2);
+      emb_edge d1 d2 : adjn d1 d2 = f d1 -- f d2
+    }.
+
+(** Recall that the darts of a plain hypermap represent
+"half-edges". In particular, every node cycle of [D] lists the
+incident half edges. Thus, [emb_surj] entails that there are no
+embeddings for graphs with isolated vertices. One could imagine
+relaxing [emb_inj] exclude isolated vertices, but this would
+conidertably complicate transferring results between a graph and its
+embedding. Moreover, isolated vertices are ol little concern in the
+study of planar graps. *)
+
+(** Also note that we do *not* require that there be at most one edge
+in the embedding representing a given edge in [G]. The reason for this
+is two-fold: (1) redundant parrallel edges can easily be removed when
+this is relevant; (2) this means that there are fewer properties to
+be preserved by constructions on hypermaps, in particular when glueing
+together hypermaps along "marker" edges. *)
+
+Section Embedding.
+Variables (G : sgraph) (D : hypermap) (f : D -> G) (emb_f : embedding f).
+
+Lemma emb_vertexP d1 d2 : reflect (f d1 = f d2) (cnode d1 d2).
+Proof. rewrite (emb_vertex emb_f). exact:eqP. Qed.
+
+Definition emb_inv (x : G) : D := iinv (emb_surj emb_f x).
+
+Lemma emb_invK : cancel emb_inv f. 
+Proof. by move => z; rewrite f_iinv. Qed.
+
+Lemma emb_inv_inj : injective emb_inv.
+Proof. exact/can_inj/emb_invK. Qed.
+
+Lemma adjn_irrefl : irreflexive (@adjn D).
+Proof. move => x. by rewrite (emb_edge emb_f) sgP. Qed.
+
+Lemma adjn_face (x : D) : adjn x (face x).
+Proof.
+apply/exists_inP; exists x; first exact: connect0.
+rewrite in_applicative -plain_eq' -?cnode1r ?connect0 //.
+exact: emb_plain emb_f.
+Qed.
+
+Lemma emb_loopless : loopless D. 
+Proof. 
+  apply/existsPn => x. apply: contraNN (negbT (adjn_irrefl x)) => H.
+  apply/exists_inP; exists x => //. exact: connect0.
+Qed.
+
+Lemma emb_roots_inj : {in froots node &, injective f}.
+Proof.
+  move => x y root_x root_y /eqP. rewrite -emb_vertex //.
+  move => /rootP - /(_ cnodeC). by rewrite (eqP root_x) (eqP root_y).
+Qed.
+
+Lemma emb_roots_bij : {in froots node, bijective f}.
+Proof. 
+  exists (froot node \o (emb_inv)). 
+  - move => x /= /eqP {2}<-; apply/rootP; first exact cnodeC. 
+    by rewrite (emb_vertex emb_f) f_iinv.
+  - move => x /= _. rewrite -{2}[x]emb_invK. apply/emb_vertexP. 
+    by rewrite cnodeC connect_root.
+Qed.
+
+Lemma emb_ncard : fcard node D = #|G|.
+Proof. 
+  rewrite /n_comp_mem /predI (eq_card (predIT _)) //=.
+  apply/eqP; rewrite eqn_leq -{1}(card_in_imset emb_roots_inj) max_card /=.
+  pose g := froot node \o (emb_inv).
+  have inj_g : injective g. 
+  { apply: (@can_inj _ _ _ f) => x. rewrite /g/=. 
+    rewrite -{2}[x]emb_invK. apply/emb_vertexP. 
+    by rewrite cnodeC connect_root. }
+  rewrite -(card_imset _ inj_g) subset_leq_card //.
+  apply/subsetP => ? /imsetP [x _ ->]. rewrite /g/=. 
+  apply/eqP. apply: root_root. exact: cnodeC.
+Qed.
+
+Lemma cnode_lpath (x y : D) : 
+  cnode x y -> exists p, [/\ path clink x p, last x p = y & {subset p <= cnode x}].
+Proof.
+rewrite -same_fconnect_finv // => /connectP [p pth_p lst_p]; exists p; split => //.
+  by apply: sub_path pth_p; apply: subrelUl. 
+by apply: closed_path_sub pth_p => //= z1 z2 /eqP<- ?; rewrite cnode1r f_finv.
+Qed.
+
+Lemma adj_lpath (x y : D) : plain D -> adjn x y -> 
+  exists p, [/\ path clink x p, last x p = y & {subset p <= [predU cnode x & cnode y]}].
+Proof.
+move => plainD /exists_inP [z Z1 Z2]; rewrite inE in Z1. 
+rewrite inE cnodeC -[edge z](f_finv nodeI) -cnode1 in Z2.
+have [p [P1 P2 P3]] := cnode_lpath Z1; have [q [Q1 Q2 Q3]] := cnode_lpath Z2.
+exists (p ++ finv node (edge z) :: q); split.
+- by rewrite cat_path P1 P2 /= Q1 andbT -plain_eq' // finv_f ?clinkF.
+- by rewrite last_cat.
+- move => v. rewrite mem_cat !inE !app_predE => /or3P [/P3 ->//|/eqP->|/Q3 H].
+  + by rewrite !inE [cnode y _]cnodeC Z2.
+  + rewrite !inE in H *. by rewrite [cnode y v](connect_trans _ H) // cnodeC.
+Qed.
+
+Lemma edge_clink (x y : G) : x -- y ->
+  exists p, [/\ path clink (emb_inv x) p, last (emb_inv x) p = (emb_inv y) & 
+          {subset [set f z | z in p] <= [set x;y]}].
+Proof.
+rewrite -{1}[x]emb_invK -{1}[y]emb_invK -emb_edge //.
+move/adj_lpath => /(_ (emb_plain emb_f)) [p [P1 P2 P3]].
+exists p; split => // v /imsetP [z /P3 Hz] -> {v}; move: Hz.
+by rewrite !inE !(emb_vertex emb_f) !f_iinv ![f _ == _]eq_sym.
+Qed.
+
+Lemma emb_path x y (p : Path x y) :
+  exists (q : seq D), 
+    [/\ path clink (emb_inv x) q, f (last (emb_inv x) q) = y & {in q, forall z, f z \in p}].
+Proof.
+have plainD := emb_plain emb_f.
+elim/Path_ind : p => {x} => [|x z p xz [r [R1 R2 R3]]].
+  by exists nil; split => //=; rewrite ?emb_invK. 
+have [q [Q1 Q2 Q3]] := edge_clink xz.
+exists (q++r); rewrite cat_path last_cat !Q1 Q2 R1 R2; split => // v.
+rewrite !inE mem_cat => /orP [Hv|/R3->//].
+by rewrite mem_edgep -in_set2 Q3 // imset_f.
+Qed.
+
+Lemma emb_path_f (x y : D) (p : Path (f x) (f y)) : 
+  exists q, [/\ path clink x q, last x q = y & {in q, forall z, f z \in p}].
+Proof.
+have [q [Q1 /emb_vertexP Q2 Q3]] := emb_path p.
+have Nx: cnode x (emb_inv (f x)) by rewrite (emb_vertex emb_f) emb_invK.
+have [q1 [Q11 Q12 Q13]] := cnode_lpath Nx.
+have [q2 [Q21 Q22 Q23]] := cnode_lpath Q2.
+exists (q1 ++ q ++ q2); rewrite !cat_path !last_cat Q11 Q12 Q1 Q21 Q22.
+split => // z; rewrite !mem_cat => /or3P[/Q13||/Q23]; try exact: Q3.
+- by move/emb_vertexP<-.
+- move/emb_vertexP<-. by rewrite (emb_vertexP _ _ Q2).
+Qed.
+
+(** This could be generalized to [k.+1.-connected] graphs allowing to
+avoid up to [k] node nycles in [D]. The lemma proved here is
+sufficient for our purposes, which is prove that the faces of
+(embedded) 2-connected graphs are bounded by cycles. *)
+Lemma two_connected_avoid_one : 2.-connected G -> avoid_one D.
+Proof.
+case => cardG sepG z x y cNzx cNzy.
+have sepN : ~ vseparator [set f z] by move/sepG; rewrite cards1.
+gen have N1,_ : x cNzx / f x \notin [set f z].
+  by rewrite inE -emb_vertex // cnodeC.
+have [p Ip av_p] := avoid_nonseperator sepN (N1 _ cNzx) (N1 _ cNzy).
+rewrite disjoint_sym disjoints1 in av_p.
+suff : connect (restrict [set v | f v \in p] clink) x y.
+{ apply/connect_restrict_mono/subsetP => v; rewrite !inE.
+  by apply: contraTN; rewrite (emb_vertex emb_f) => /eqP <-. }
+have [q [Q1 Q2 Q3]] := emb_path_f p.
+apply/connectP; exists q; last by rewrite Q2. 
+apply: path_rpath => //; first by rewrite inE. 
+move => z' /Q3; by rewrite inE.
+Qed.
+
+
+Lemma emb_inv_node d : cnode d (emb_inv (f d)).
+Proof. by rewrite (emb_vertex (emb_f)) emb_invK. Qed.
+
+Lemma emb_degree d : #|N(f d)| <= order node d.
+Proof.
+set x := f d.
+have Nxd z : z \in N(x) -> exists ez, cnode (emb_inv z) (edge ez) && cnode (emb_inv x) ez.
+{ rewrite in_opn -{1}[x]emb_invK -{1}[z]emb_invK -emb_edge /adjn //.
+  case/exists_inP => dz; rewrite !inE. exists dz; apply/andP => //. }
+pose h (z:G) := if @idP (z \in N(x)) is ReflectT zx then xchoose (Nxd _ zx) else d.
+have I : {in N(x)&, injective h}. 
+{ move => u v. rewrite /h. 
+  case: {1}_ / idP => // ux _. case: {1}_ / idP => // vx _. 
+  case: xchooseP' => du. case: xchooseP' => dv. 
+  move=> /andP [C1 _] /andP[C2 _] E; subst dv; apply/eqP.
+  rewrite -[u]emb_invK -[v]emb_invK -emb_vertex //.
+  by apply: connect_trans C2 _; rewrite cnodeC. }
+rewrite -(card_in_imset I).
+apply/subset_leq_card/subsetP => dz /imsetP [z xz ->] {dz}.
+rewrite /h; case: {-}_ / idP => [p|]; last by rewrite xz.
+case: xchooseP' => dz /andP [_ D2]. exact: connect_trans (emb_inv_node _) _.
+Qed.
+
+Lemma emb_gcomp x y : gcomp x y = connect (--) (f x) (f y).
+Proof.
+have ? : plain D by apply: emb_plain emb_f.
+rewrite -clink_glink; apply/idP/idP; move/connectP => [p].
+- move=> pth_p ->; elim: p x pth_p => //= z p IHp x /andP [xz {}/IHp].
+  apply: connect_trans; have [/eqP<-|/eqP<-] := orP xz.
+  + by apply/eq_connect0/eqP; rewrite -emb_vertex // cnode1r f_finv.
+  + by apply: connect1; rewrite -emb_edge //= adjn_face.  
+- move => pth_p lst_p; have q := Path_of_path pth_p; rewrite -lst_p in q.
+  by have [r [pth_r lst_r _]] := emb_path_f q; apply/connectP; exists r.
+Qed.
+
+Lemma emb_n_comp : n_comp glink D = n_comp (--) G.
+Proof.
+symmetry; have eq_D : D =1 [preim f of G] by [].
+rewrite (eq_n_comp_r eq_D).
+apply: adjunction_n_comp => //;[exact: sconnect_sym|exact: glinkC|].
+split => [x _|x' y' _]; last exact: emb_gcomp.
+by exists (emb_inv x); rewrite f_iinv connect0.
+Qed.
+
+Lemma hiso_embed (E : hypermap) (i : hiso E D) : 
+  embedding f -> embedding (f \o i).
+Proof.
+case => E1 E2 E3 E4. split. 
+- by rewrite (hiso_plain i).
+- move => x; case/mapP : (E2 x) => x0 _ ->. by rewrite -[x0](bijK' i) codom_f.
+- move => x y /=. by rewrite (hiso_cnode i).
+- move => x y /=. by rewrite -E4 hiso_adjn.
+Qed.
+
+Lemma emb_fcycle_cycle p : fcycle face p -> cycle (--) [seq f z | z <- p].
+Proof. 
+case: p => //= x p; rewrite -map_rcons; apply: homo_path => {x} x y /eqP<-.
+by rewrite -emb_edge // adjn_face.
+Qed.
+
+Lemma emb_face_cycle (x : D) : cycle (--) [seq f z | z <- orbit face x].
+Proof. exact/emb_fcycle_cycle/cycle_orbit/faceI. Qed.
+
+(** The remaining properties assume that there are no redundant parallel edges *)
+Hypothesis simpleD : simple_hmap D.
+
+Lemma emb_ecard : fcard edge D = #|E(G)|.
+Proof.
+have ? : plain D by apply: emb_plain emb_f.
+rewrite /n_comp_mem (eq_card (predIT _)) //.
+apply/eqP; rewrite eqn_leq; apply/andP; split.
+- pose h (x : D) := [set f x; f (edge x)].
+  have h_inj :  {in froots edge &, injective h}. 
+  { move=> x y root_x root_y. apply: contra_eq => xDy. 
+    have : ~~ cedge x y. 
+    rewrite -root_connect ?(eqP root_x) ?(eqP root_y) //. 
+    exact: fconnect_sym.
+    apply: contraNneq; rewrite /h doubleton_eq_iff !(rwP eqP) -!emb_vertex //.
+    case => [[?]|[]]; first by rewrite (negPf (simpleD _ _)).
+    have [->|xDey] := eqVneq x (edge y); first by rewrite -cedge1.
+    by move/(simpleD xDey)/negPf; rewrite plain_eq // => ->. }
+  rewrite -(card_in_imset h_inj); apply: subset_leq_card.
+  apply/subsetP => z /imsetP [x _ ->].
+  by rewrite in_edges -emb_edge ?adjn_edge.
+- have [e0 /edgesP [x0 _]|->] := picksP E(G); last by rewrite cards0.
+  pose d0 := emb_inv x0.
+  have link x y : x -- y -> { d : D | f d = x & f (edge d) = y }. 
+  { rewrite -[x]emb_invK -[y]emb_invK -emb_edge // => /existsP ex_d.
+    exists (xchoose ex_d); apply/eqP; case/andP : (xchooseP ex_d) => ? ?.
+    all: by rewrite -emb_vertex // cnodeC. }
+  pose g (e : {set G}) : D := 
+    if edgeP e is Edge x y xy _ then froot edge (s2val (link x y xy)) else d0.
+  have g_inj : {in E(G)&, injective g}.
+  { move=> e1 e2 E1 E2; rewrite /g.
+    case: (edgeP e1) => [x y xy ->|]; last by rewrite {1}E1.
+    case: (edgeP e2) => [u v uv ->|]; last by rewrite {1}E2.
+    case: (link x y xy) => d1 /= f_d1 f_ed1.
+    case: (link u v uv) => d2 /= f_d2 f_ed2. 
+    move/eqP; rewrite root_connect; last exact: fconnect_sym.
+    rewrite plain_orbit // !inE => /pred2P [?|?]; subst => //.
+    by rewrite plain_eq // setUC. }
+  rewrite -(card_in_imset g_inj); apply: subset_leq_card.
+  apply/subsetP => z /imsetP [x E ->]; rewrite inE /g. 
+  case: edgeP => [*|] ; rewrite ?E ?roots_root //. exact: fconnect_sym.
+Qed.
+
+Lemma card_emb : #|D| = #|E(G)|.*2.
+Proof.
+by rewrite -emb_ecard -muln2 fcard_order_set //; exact: emb_plain emb_f.
+Qed.
+
+(** it would be sufficient to assume that the vertices involved in the
+face have arity 3 *)
+Lemma emb_arity3 (x : D) : (forall y, 1 < #|N(f y)|) -> 2 < arity x.
+Proof.
+move => deg2.
+apply: arity3 => //;[exact: emb_plain emb_f|exact: emb_loopless|].
+move=> {x} x. apply: contraTF (deg2 x); rewrite -leqNgt => /eqP nxx.
+apply: leq_trans (emb_degree _) _. exact: order_le_fix.
+Qed.
+
+End Embedding.
+
+
+Lemma homo_cycle (aT rT : Type) (f : aT -> rT) (e1 : rel aT) (e2 : rel rT) (s : seq aT) :
+  {homo f : x y / e1 x y >-> e2 x y} -> cycle e1 s -> cycle e2 (map f s).
+Proof. 
+case: s => //= a s hom_f; rewrite !rcons_path => /andP [pth_s /hom_f lst_s].
+by rewrite (homo_path hom_f pth_s) last_map.
+Qed.
+
+(** ** Packaged plane embeddings *)
+
+Record plane_embedding (G : sgraph) :=
+  { emb_map : hypermap;
+    emb_fun :> emb_map -> G;
+    emb_embedding : embedding emb_fun;
+    emb_planar : planar emb_map }.
+
+#[export] Hint Resolve emb_embedding emb_planar : core.
+
+Section PlaneEmbedding.
+Variables (G : sgraph) (g : plane_embedding G).
+Implicit Types (x y : G) (d : emb_map g).
+
+Lemma plane_emb_plain : plain (emb_map g).
+Proof. exact: emb_plain. Qed.
+
+Lemma plane_emb_loopless : loopless (emb_map g).
+Proof. exact: emb_loopless. Qed.
+
+Lemma plane_emb_surj : forall x, x \in codom g.
+Proof. exact: emb_surj. Qed.
+
+Lemma plane_emb_vertex d1 d2 : cnode d1 d2 = (g d1 == g d2).
+Proof. exact: emb_vertex. Qed.
+
+Lemma plane_emb_edge d1 d2 : adjn d1 d2 = g d1 -- g d2.
+Proof. exact: emb_edge. Qed.
+
+Definition pinv := emb_inv (emb_embedding g).
+Lemma pinvK : cancel pinv g.
+Proof. exact: emb_invK. Qed.
+
+End PlaneEmbedding.
+
+(** In this section we define faces on plane graphs (i.e, simple
+graphs [G] endowed with some plane embedding) and lift various
+properties estblished on hypermaps. *)
+
+Section Lifting.
+Variables (G : sgraph) (g : plane_embedding G).
+Implicit Types (s : seq G).
+
+Let gedge := @edge (emb_map g).
+Let gnode := @node (emb_map g).
+Let gface := @face (emb_map g).
+
+Notation "(--)" := (fun x y => x -- y).
+
+Definition sface s := exists d : emb_map g, s = map g (orbit gface d).
+
+Lemma sface_cyle s : sface s -> cycle (--) s.
+Proof. 
+case => d ->. apply: homo_cycle (cycle_orbit faceI _).
+move => x y /=. rewrite -emb_edge // => /eqP <-. exact: adjn_face.
+Qed.
+
+Proposition face_uniq (s : seq G) : 2.-connected G -> sface s -> uniq s.
+Proof.
+move => tcG; have := @two_connected_cyle (emb_map g).
+case/(_ _ _ _ _ )/Wrap; auto using plane_emb_plain, plane_emb_loopless.
+- exact/(two_connected_avoid_one (emb_embedding g)).
+- move=> Hg [x ->]; rewrite map_inj_in_uniq ?orbit_uniq //.
+  move => u v; rewrite -!fconnect_orbit => Hu Hv. 
+  apply: contra_eq => uDv; rewrite -plane_emb_vertex.
+  apply: Hg uDv _. apply: connect_trans Hv. 
+  by rewrite cfaceC.
+Qed.  
+
+Lemma rot_orbit (T : finType) (f : T -> T) x n (injf : injective f) :
+  n < order f x -> rot n (orbit f x) = orbit f (iter n f x).
+Proof.
+move=> n_lt_ordx. 
+rewrite [RHS](orbitE (cycle_orbit injf x)) -/(findex f _ _) ?findex_iter //.
+by rewrite -fconnect_orbit fconnect_iter.
+Qed.
+
+Lemma rot_face n (s : seq G) : sface s -> sface (rot n s).
+Proof.
+have [n_lt_s face_s|?] := ltnP n (size s); last by rewrite rot_oversize.
+case: face_s n n_lt_s => x -> n; rewrite size_map size_orbit => n_lt_o.
+rewrite -map_rot rot_orbit //; [by eexists|exact: faceI].
+Qed.
+
+Lemma rotr_face n (s : seq G) : sface s -> sface (rotr n s). 
+Proof. exact: rot_face. Qed.
+
+
+(** Always holds, [2 < arity x] can be obtained by removing parallel edges] *)
+Lemma plane_emb_arity2 (d : emb_map g) : 1 < arity d.
+Proof.
+apply: loopless_arity. apply: plane_emb_plain. apply: plane_emb_loopless. 
+Qed.
+
+Lemma plane_emb_face x y : x -- y -> exists s, sface (x::y::s).
+Proof.
+have [dx /esym g_dx] := codomP (plane_emb_surj g x).
+have [dy /esym g_dy] := codomP (plane_emb_surj g y).
+rewrite -{1}g_dx -{1}g_dy -plane_emb_edge => /exists_inP [z]; rewrite !inE.
+rewrite plane_emb_vertex => /eqP dx_z dx_ez.
+set v := finv node (edge z).
+have fz : face z = v. 
+{ rewrite /v -plain_eq' ?finv_f //. exact: plane_emb_plain. }
+exists (drop 2 (map g (orbit face z))), z ; rewrite /sface.
+have X : 1 < arity z by apply plane_emb_arity2.
+rewrite [in RHS](orbit_prefix X) /= map_drop; congr (_ :: _ :: _).
+- by rewrite -g_dx.
+- by apply/eqP; rewrite -g_dy fz /v -plane_emb_vertex cnode1r f_finv.
+Qed.
+
+End Lifting.
+
+Prenex Implicits Icp.
+
+(** ** Constructions on Plane Embeddings *)
+
+(** Union *)
+
+Lemma union_plane_embedding (G H : sgraph) : 
+  plane_embedding G -> plane_embedding H -> plane_embedding (G ∔ H).
+Proof.
+move=> g h; pose D := (emb_map g ∔ emb_map h)%H.
+pose g' : D -> (G ∔ H)%sg := sumf g h.
+have emb_g' : embedding g'. 
+{ split.
+  - have ? := plane_emb_plain g; have ? := plane_emb_plain h.
+    apply/plainP => -[x|x] _ /=; rewrite inj_eq ?plain_eq ?plain_neq //.
+    exact: inl_inj. exact: inr_inj.
+  - move=> [y|y]; apply/codomP. 
+    + by have/codomP [x ->] := plane_emb_surj g y; exists (inl x).
+    + by have/codomP [x ->] := plane_emb_surj h y; exists (inr x).
+  - move => [x|x] [y|y].
+    all: rewrite /= fconnect_sumf // ?(inj_eq inl_inj) ?(inj_eq inr_inj).
+    all: exact/emb_vertex/emb_embedding.
+  - move => [x|x] [y|y]; rewrite union_adjn //= /edge_rel/=.
+    all: exact: plane_emb_edge.
+ }
+have : planar D by apply/union_planar; split; exact: emb_planar.
+exact: Build_plane_embedding emb_g'.
+Qed.
+
+(** Adding a new node linked to another node *)
+
+Lemma plane_add_node1 (G : sgraph) (g : plane_embedding G) (x : G) s : 
+  sface g (x::s) -> 
+  exists g' : plane_embedding (add_node G [set x]), 
+    sface g' [:: Some x, None, Some x & map Some s].
+Proof.
+pose D := emb_map g.
+case => z forbit_z. 
+set G' := add_node G [set x].
+pose D' := h_add_node z.
+pose g' (z' : D') : G' := match z' with
+                         | IcpX => Some (g z)
+                         | IcpXe => None
+                         | Icp z' => Some (g z')
+                         end.
+have gz : g z = x.
+{ by move: forbit_z; rewrite /orbit -orderSpred /=; case=> -> _. }
+have [plain_D surj_g vertex_g edge_g] := emb_embedding g.
+have plain_D' := add_node_plain z plain_D : plain D'.
+have embedding_g' : embedding g'.
+{ split.
+  - by apply: add_node_plain (plane_emb_plain _).
+  - move => [u|]; last by apply/codomP; exists IcpXe.
+    by have [d _ ->] := mapP (surj_g u); apply/codomP; exists (Icp d).
+  - have ? := @nodeI D'.
+    move => [||d1] [||d2]; rewrite /= ?connect0 ?eqxx //=.
+    all: rewrite ?[_ _ IcpXe](@cnodeC D') ?add_node_cnodeXe //.
+    all: rewrite ?[_ _ IcpX](@cnodeC D') ?Some_eqE ?[_ IcpX _]same_fconnect1 //=.
+    all: rewrite ?(@add_node_cnodeE) -?cnode1 // 1?cnodeC //.
+  - have adjn_Icp := @add_node_adjn D z. 
+    pose m (d : D') := match d with IcpX => 1 | IcpXe => 2 | _ => 0 end.
+    move => d1 d2; wlog: d1 d2 / m d1 <= m d2 => [W|].
+    { have [|/ltnW] := leqP (m d1) (m d2); first exact: W.
+      rewrite sg_sym adjnC //. exact: W. }
+    move: d1 d2 => [||d1] [||d2] // _ ; rewrite /= ?sg_irrefl. 
+    all: rewrite /edge_rel/= ?inE ?eqxx ?[in g z == x]gz ?eqxx.
+    + by rewrite adjn_node1 adjn_node1r /= adjn_Icp edge_g sg_irrefl.
+    + exact: adjn_edge.
+    + exact: add_node_adjnXeXe.
+    + by rewrite adjn_node1r /= adjn_Icp -adjn_node1r.
+    + by rewrite -gz -vertex_g adjnC // add_node_adjnXe cnodeC.
+    + by rewrite adjn_Icp.
+ }
+have planar_D' : planar D' by rewrite add_node_planar; apply: emb_planar.
+exists (Build_plane_embedding embedding_g' planar_D').
+exists (IcpX) => /=.
+rewrite add_node_face_orbitE /= gz -map_cons forbit_z; congr ([:: _ , _ & _]).
+by rewrite -!map_comp; apply: eq_map.
+Qed.
+
+(** Adding an Edge across a face *)
+
+Lemma face_preim (G : sgraph) (g : plane_embedding G) (x0 : emb_map g) (p := orbit face x0) x (s : seq G) :
+  s = [seq g x | x <- p] -> x \in s -> exists2 d, d \in p & x = g d.
+Proof. by move=> -> /mapP. Qed.
+
+Lemma arcEmap (aT rT : eqType) (f : aT -> rT) (x y : aT) (p : seq aT) (s := [seq f x | x <- p]) :
+  uniq s -> uniq p -> 
+  x != y -> x \in p -> y \in p -> arc s (f x) (f y) = [seq f x | x <- arc p x y].
+Proof.
+move=> uniq_s uniq_p xDy x_p y_p. 
+have [i p1 p2 arc1 arc2 rot_i] := rot_to_arc uniq_p x_p y_p xDy.
+rewrite /s -(arc_rot i) ?map_f // -map_rot rot_i /= map_cat /= -arc1 left_arc //.
+by move: uniq_s; rewrite /s -(rot_uniq i) -map_rot rot_i /= map_cat.
+Qed.
+
+Lemma orbit_case (T : finType) (f : T -> T) (x : T) : exists o, orbit f x = x :: o.
+Proof. by rewrite /orbit -orderSpred /=; eexists. Qed.
+
+Lemma plane_add_edge (G : sgraph) (g : plane_embedding G) (x y : G) (s1 s2 : seq G) : 
+  let s := x :: s1 ++ y :: s2 in
+  x != y -> sface g s -> 
+  exists2 g' : plane_embedding (add_edge x y), 
+    sface g' [:: y, x & s1] & sface g' [:: x,y & s2].
+Proof.
+move=> s xDy sface_xy.
+case: sface_xy => dx E.
+set o := orbit face dx in E.
+pose dy := nth dx o (size s1).+1.
+have lt_size_o : (size s1).+1 < size o.
+{ by rewrite -[size o](size_map g) -E /s -cat_cons size_cat /= addnS addSn !ltnS leq_addr. }
+have g_y : g dy = y. 
+{ rewrite /dy -(nth_map _ x) -?E //.
+  by rewrite /s -cat_cons nth_cat ltnn subnn. }
+have g_x : g dx = x. 
+{ by move: E; rewrite /o/orbit/s -orderSpred/=; case => -> _. }
+have dxDdy : dx != dy. 
+{ by apply: contra_neq xDy => dxy; rewrite -g_x dxy g_y. }
+have dx_dy : cface dx dy by rewrite fconnect_orbit mem_nth //.
+set D := emb_map g in dx o E dy g_x lt_size_o g_y dxDdy dx_dy .
+pose D' := h_add_edge dxDdy. 
+pose g' (d : D') : add_edge x y :=
+  match d with IcpX => x | IcpXe => y | Icp z => g z end.
+have [plain_D surj_g vertex_g edge_g] := emb_embedding g.
+have plain_D' : plain D' by apply: add_edge_plain. 
+have embedding_g' : embedding g'. 
+{ split => //. 
+  - move=> z. have [dz ->] := codomP (surj_g z). by apply/codomP; exists (Icp dz).
+  - have ? := @nodeI D'.
+    have cnode_Icp := add_edge_cnodeE dxDdy.
+    have fD' : add_edge_node dx dy = @node D' by [].
+    move => [||d1] [||d2]; rewrite /= ?connect0 ?eqxx //= ?fD'.
+    1,3: by rewrite ?[cnode _ (IcpX : D')]cnodeC add_edge_cnodeXXe 
+            vertex_g g_x g_y ?[y == x]eq_sym.
+    all: rewrite -?g_x -?g_y. 
+    1-2: rewrite ?[_ _ IcpX](@cnodeC D') //. (* by fails ? *)
+    1-2: rewrite (@cnode1 D'). 3-4: rewrite (@cnode1r D').
+    1-5: by rewrite cnode_Icp -?cnode1 -?cnode1r.    
+  - have adjn_Icp := @add_edge_adjn D _ _ dxDdy. 
+    pose m (d : D') := match d with IcpX => 1 | IcpXe => 2 | _ => 0 end.
+    move => d1 d2; wlog: d1 d2 / m d1 <= m d2 => [W|].
+    { have [|/ltnW] := leqP (m d1) (m d2); first exact: W.
+      rewrite sg_sym adjnC //. exact: W. }
+    have dxdyF : cnode dx dy = false by rewrite vertex_g g_x g_y (negbTE xDy).
+    move: d1 d2 => [||d1] [||d2] // _ ; rewrite /= ?sg_irrefl.
+    + by rewrite adjn_node1 adjn_node1r /= adjn_Icp edge_g sg_irrefl -!cnode1 dxdyF.
+    + by rewrite /edge_rel/= (negbTE xDy) !eq_refl orbT adjn_edge.
+    + rewrite adjn_node1 adjn_node1r /= adjn_Icp edge_g sg_irrefl.
+      by rewrite -!cnode1 cnodeC dxdyF.
+    + rewrite adjn_node1r /= adjn_Icp -!cnode1 -adjn_node1r.
+      rewrite dxdyF connect0 andbF andbT /=.
+      rewrite edge_g [RHS]/edge_rel/=  g_x (negbTE xDy) !andbF eqxx /=.
+      by apply:orb_id2l => _; rewrite vertex_g g_y andb_idl // => /eqP->.
+    + rewrite adjn_node1r /= adjn_Icp -!cnode1 -adjn_node1r [cnode dy dx]cnodeC.
+      rewrite dxdyF connect0 andbF andbT /= edge_g [RHS]/edge_rel/=.
+      rewrite [y == x]eq_sym eqxx (negbTE xDy) !andbF !orbF !andbT g_y.
+      by apply:orb_id2l => _; rewrite vertex_g g_x andb_idl // => /eqP->.
+    + rewrite adjn_Icp [RHS]/edge_rel/= edge_g !vertex_g g_x g_y.
+      apply: orb_id2l => _; rewrite ?[x == _]eq_sym ?[y == _]eq_sym.
+      rewrite ![(_ != _) && _]andb_idl ?[(g d2 == x) && _]andbC //.
+      all: by move=> /andP[/eqP-> /eqP->]. }
+have planar_D := emb_planar g.
+have planar_D' : planar D' by apply: add_edge_planar. 
+have [o' def_o] := orbit_case face dx; rewrite -/o in def_o.
+have dy_o' : dy \in o'.
+{ by have := mem_nth dx lt_size_o; rewrite -/dy def_o inE eq_sym (negbTE dxDdy). }
+pose o1 := take (index dy o') o'; pose o2 := drop (index dy o').+1 o'.
+have size1 : size s1 = size o1. 
+{ rewrite /o1 size_take index_mem dy_o' /dy def_o /= index_uniq //.
+  - by rewrite -ltnS -[(size o').+1]/(size (dx::o')) -def_o. 
+  - apply: subseq_uniq (orbit_uniq face dx). rewrite -/o def_o. exact: subseq_cons. }
+have [def_s1 def_s2 def_o'] : 
+  [/\ s1 = [seq g d | d <- o1], s2 = [seq g d | d <- o2] & o' = o1 ++ dy :: o2].
+{ move: size1 E. rewrite def_o /o1 /o2 /s. 
+  case/splitP : _ _ _ / dy_o' => [p1 p2 _] size1 /=.
+  move/eqP; rewrite g_x eqseq_cons eqxx -cats1 -catA /= map_cat /=.
+  by rewrite eqseq_cat ?size_map // eqseq_cons g_y eqxx /= => /andP[/eqP-> /eqP->]. }
+rewrite def_o' in def_o; exists (Build_plane_embedding embedding_g' planar_D').
+- exists (IcpXe) => /=. rewrite add_edge_orbitXe //= -/o. 
+  rewrite def_o left_arc -?def_o ?orbit_uniq //= -map_comp g_x /=.
+  by rewrite (@eq_map _ _ _ g) // def_s1.
+- exists (IcpX) => /=. rewrite add_edge_orbitX //= -/o.
+  rewrite def_o right_arc -?def_o ?orbit_uniq //= -map_comp g_y /=.
+  by rewrite (@eq_map _ _ _ g) // def_s2.
+Qed.
+
+(* TOTHINK: using [arc], we would need [uniq s] *)
+Lemma plane_add_edge' (G : sgraph) (g : plane_embedding G) (x y : G) (s : seq G) : 
+  x != y -> sface g s -> x \in s -> y \in s -> uniq s ->
+  exists g' : plane_embedding (add_edge x y), 
+    sface g' (rcons (arc s x y) y) /\ sface g' (rcons (arc s y x) x).
+Proof.
+Abort.
+
+(** Adding a "fan", i.e. a new vertex connected to a number of other vertices, all on the same face *)
+
+Section AddEdges2.
+Variables (G : sgraph) (U V : {set G}).
+Definition add_edges2_rel := 
+  [rel u v : G | u -- v || (u != v) && ((u \in U) && (v \in V) || (u \in V) && (v \in U))].
+
+Fact add_edges2_irrefl : irreflexive add_edges2_rel.
+Proof. by move=> x /=; rewrite sg_irrefl eqxx. Qed.
+
+Fact add_edges2_sym : symmetric add_edges2_rel.
+Proof. 
+by move=> x y; rewrite /= ![_ && (x \in _)]andbC [_ && _ || _]orbC eq_sym sg_sym.
+Qed.
+
+Definition add_edges2 := SGraph add_edges2_sym add_edges2_irrefl.
+End AddEdges2.
+
+Arguments add_edges2 : clear implicits.
+
+Lemma add_node_diso_proof (G : sgraph) (A : {set G}) (x : G) : x \in A ->
+     @add_edges2_rel (add_node G [set x]) [set None] [set Some x | x in A :\ x] 
+  =2 add_node_rel A.
+Proof.
+move=> x_A [u|] [v|] //=; rewrite [in LHS]/edge_rel/= ?inE //.
+- rewrite andbT andFb /= inj_imset ?inE; last exact: Some_inj.
+  by have [->|//] := eqVneq u x; rewrite x_A.
+- rewrite andbF andTb orbF inj_imset ?inE; last exact: Some_inj.
+  by have [->|//] := eqVneq v x; rewrite x_A.
+Qed.
+
+Lemma add_node_diso (G : sgraph) (A : {set G}) (x : G) : 
+  x \in A -> 
+  diso (add_edges2 (add_node G [set x]) [set None] (Some @: (A :\ x))) (add_node G A).
+Proof. by move=> x_A; exact/eq_diso/add_node_diso_proof. Defined.
+
+Lemma diso_embedding (G H : sgraph) (g : plane_embedding G) (i : diso G H) : embedding (i \o g).
+Proof.
+case: g => D g [G1 G2 G3 G4] _ /= ; split => //=.
+- move=> x; have [d ? gd] := mapP (G2 (i^-1 x)). 
+  apply/mapP; exists d => //=. by rewrite -gd bijK'.
+- move=> d1 d2; by rewrite inj_eq.
+- move=> d1 d2; by rewrite edge_diso.
+Qed.
+
+Definition diso_plane_embedding (G H : sgraph) (g : plane_embedding G) (i : diso G H) := 
+  Build_plane_embedding (diso_embedding g i) (emb_planar g).
+
+Lemma diso_plane_embedding_inh (G H : sgraph) : 
+   inhabited (plane_embedding G) -> diso G H -> inhabited (plane_embedding H).
+Proof. move => [g i]; constructor. exact: diso_plane_embedding i. Qed.
+
+Lemma iff_exists (T : Type) (P Q: T -> Prop) : 
+  (forall x, P x <-> Q x) -> (exists x : T, P x) <-> (exists x : T, Q x).
+Proof. firstorder. Qed.
+
+Lemma diso_face (G H : sgraph) (g : plane_embedding G) (i : diso G H) s : 
+  sface g s <-> sface (diso_plane_embedding g i) (map i s). 
+Proof.
+apply: iff_exists => d /=. 
+rewrite map_comp [map _ _ = _](rwP eqP) inj_eq -?(rwP eqP) //. 
+exact: inj_map.
+Qed.
+
+Arguments add_edge : clear implicits.
+Arguments add_edges2_rel : clear implicits.
+
+Lemma add_edge1n_diso_proof (G : sgraph) (A : {set G}) (x y : G) :
+  @add_edges2_rel (add_edge G x y) [set x] A =2 add_edges2_rel _ [set x] (y |: A).
+Proof.
+move=> u v. rewrite /= !inE /edge_rel/= /edge_rel /=.
+case (sedge _ _) => //=. case: (eqVneq u v) => H; subst => //=. 
+case: (eqVneq u x) => ?; subst => //=. 
+all: case: (eqVneq v x) => ?; subst => //=. by rewrite eqxx in H.
+Qed.
+
+Lemma add_edge1n_diso (G : sgraph) (A : {set G}) (x y : G) :
+  y \notin A -> diso (add_edges2 (add_edge G x y) [set x] A)
+               (add_edges2 G [set x] (y |: A)).
+Proof. by move=> yNA; apply: eq_diso; exact: add_edge1n_diso_proof. Defined.
+
+Lemma add_edge11_diso_proof (G : sgraph) (x y : G) : 
+  add_edge_rel x y =2 add_edges2_rel _ [set x] [set y].
+Proof.
+move => u v; rewrite /= !in_set1 andb_orr; congr [|| _ , _ | _]. 
+by rewrite [v == u]eq_sym [(v == x) && _]andbC.
+Qed.
+
+Lemma add_edge11_diso (G : sgraph) (x y : G) : 
+  diso (add_edge G x y) (add_edges2 G [set x] [set y]).
+Proof. apply: eq_diso; exact: add_edge11_diso_proof. Defined.
+
+Lemma set_nil (T : finType) : [set x in Nil T] = set0.
+Proof. by apply/setP => x; rewrite inE. Qed.
+
+Lemma subseq_notin (T : eqType) (z : T) (p s1 s2 : seq T) :
+  z \notin s1 -> subseq (z :: p) (s1 ++ z :: s2) -> subseq p (z :: s2).
+Proof.
+elim: s1 => [_|a s1 IH]. 
+- rewrite cat0s [X in X -> _]/= eqxx => sub_p.
+  exact: subseq_trans sub_p (subseq_cons _ _).
+- rewrite inE negb_or [X in _ -> X -> _]/= => /andP[/negPf-> zNs1].
+  exact: IH.
+Qed.
+
+Lemma undup_subseq (T : eqType) (s : seq T) : subseq (undup s) s.
+Proof. 
+elim: s => // x s IHs; rewrite [undup _]/=; case: ifP; last by rewrite /= eqxx.
+by move=> _; apply: subseq_trans IHs (subseq_cons _ _).
+Qed.
+
+Lemma plane_add_fan (G : sgraph) (g : plane_embedding G) x y s1 s2 (A : {set G}) : 
+  x != y -> sface g (x :: s1 ++ y :: s2) -> x \notin A -> y \in A -> {subset A <= rcons s1 y} -> 
+  exists g' : plane_embedding (add_edges2 G [set x] A), sface g' [:: x, y & s2].
+Proof.
+move=> xDy face_g xNA y_A subA.
+pose As := undup [seq z <- s1 | z \in A :\ y].
+have subAs : subseq As s1.
+  by apply: subseq_trans (undup_subseq _) _; apply: filter_subseq.
+have yNAs : y \notin As by rewrite mem_undup mem_filter !inE eqxx.
+have xNAs : x \notin As by rewrite mem_undup mem_filter !inE (negPf xNA).
+have -> : A = y |: [set z in As]. 
+  apply/setP => u; rewrite !inE mem_undup mem_filter !inE. 
+  have [-> //|/= uDy] := eqVneq u y. rewrite andb_idr // => /subA.
+  by rewrite mem_rcons inE (negPf uDy).
+have uniq_As : uniq As by apply: undup_uniq.
+move: As subAs xNAs yNAs uniq_As => {A y_A xNA subA} As.
+have [n Hn] := ubnP (size As).
+elim: n G g x y s1 s2 xDy face_g As Hn => // n IH G g x y s1 s2 xDy face_g.
+case => [_ _ _ _ _|z As /= /ltnSE lt_As_n].
+- rewrite set_nil setU0. 
+  have [h _ face_h] := plane_add_edge xDy face_g.
+  set i := add_edge11_diso x y; exists (diso_plane_embedding h i). 
+  by move/(diso_face h i): face_h; rewrite map_id_in.
+- rewrite !inE !negb_or => subAs /andP[xDz xNAs] /andP [yDz yNAs] /andP[zNAs uniq_As].
+  have z_s1 : z \in s1 by apply/(mem_subseq subAs)/mem_head.
+  case/splitPr def_s1 : _ / z_s1 => [p1 p2 zNp1].
+  have/plane_add_edge: sface g (x :: p1 ++ z :: p2 ++ y :: s2). 
+   by move: face_g; rewrite def_s1 /= -catA.
+  move/(_ xDz) => [g' _ face_g']. 
+  have [//||//|//|//|h face_h] := IH (add_edge G x z) g' x y (z::p2) s2 xDy _ _ lt_As_n.
+  + by move: subAs; rewrite def_s1; exact: subseq_notin. 
+  + set G' := add_edges2 _ _ _. 
+    have @i: diso (add_edges2 (add_edge G x z) [set x] (y |: [set z0 in As])) G'.
+    { apply: eq_diso.
+      abstract (rewrite set_cons setUA set2C -setUA; exact: add_edge1n_diso_proof). }
+    exists (diso_plane_embedding h i). 
+    by move/(diso_face h i): face_h; rewrite map_id_in.
+Qed.
+
+Lemma plane_add_node (G : sgraph) (g : plane_embedding G) (x y : G) s1 s2 (A : {set G}) :
+  x != y -> sface g (x :: s1 ++ y :: s2) -> {subset A <= x :: rcons s1 y} -> x \in A -> y \in A ->
+  exists (g' : plane_embedding (add_node G A)), sface g' [:: Some x, None & [seq Some z | z <- y::s2]].
+Proof.
+move=> xDy face_s subA x_A y_A.
+suff [h face_h] : 
+  exists h : plane_embedding (add_edges2 (add_node G [set x]) [set None] (Some @: (A :\ x))), 
+        sface h [:: Some x, None & [seq Some z | z <- y :: s2]].
+{ set i := add_node_diso x_A; exists (diso_plane_embedding h i). 
+  by move: face_h; rewrite (diso_face _ i) map_id_in. }
+have [g'] := plane_add_node1 face_s.
+set G' := add_node _ _; rewrite map_cat /=.
+set y' := Some y; set x' := Some x; set s1' := map Some s1; set s2' := map Some s2.
+set A' := Some @: (A :\ x).
+move/(rot_face 1) => face_g'.
+have {face_g'} face_g' : sface g' (None :: (x'::s1') ++ y' :: rcons s2' x').
+{ by move: face_g'; rewrite rot1_cons /= rcons_cat /=. }
+have y_A' : y' \in A' by rewrite imset_f // !inE eq_sym xDy.
+have subA' : {subset A' <= x' :: rcons s1' y'}.
+{ move=> ? /imsetP [u /setD1P [uDx /subA uA] ->]. 
+  by move: uA; rewrite -(mem_map Some_inj) /= map_rcons. }
+have [//||h face_h] := plane_add_fan _ face_g' _ y_A' subA'.
+  by apply/negP=>/imsetP [?].
+exists h. move/(rotr_face 1) : face_h. by rewrite -!rcons_cons rotr1_rcons.
+Qed.
+
+Lemma plane_add_node' (G : sgraph) (g : plane_embedding G) (x y : G) s (A : {set G}) : 
+  x \in s -> y \in s -> x != y -> sface g s -> {subset A <= rcons (arc s x y) y} -> uniq s ->
+  x \in A -> y \in A -> 
+  exists (g' : plane_embedding (add_node G A)), 
+    sface g' [:: Some x, None & [seq Some z | z <- arc s y x]].
+Proof.
+move=> x_s y_s xDy face_s subA uniq_s x_A y_A.
+have [i s1 s2 arc1 arc2 rot_i] := rot_to_arc uniq_s x_s y_s xDy.
+rewrite -(arc_rot i) // rot_i right_arc -?rot_i ?rot_uniq //.
+apply: (plane_add_node (g := g) (s1 := s1)) => //.
+- rewrite -rot_i. exact: rot_face.
+- by rewrite -(arc_rot i) // rot_i left_arc -?rot_i ?rot_uniq in subA.
+Qed.
+
+
+
+Lemma foo (T : finType) (s : seq T) (A : {set T}) : 
+  1 < #|A| -> {subset A <= s} -> 
+  exists x y s1 s2 s3, 
+    [/\ x \in A, y \in A, x != y, s = s1 ++ x :: s2 ++ y :: s3 & [disjoint A & s2]].
+Proof.
+move=> lt1A; elim/(size_ind (@size T)) : s => s IH subAs.
+have hasAs : has (mem A) s. 
+{ case/card_gt0P : (ltnW lt1A) => x xA; apply/hasP; exists x => //. exact: subAs. }
+case/split_find def_s : {-}s _ _ / hasAs => [/= x s1 s2 xA nAs1].
+have hasAs2 : has (mem A) s2. 
+{ apply: contraTT lt1A => nAs2; rewrite -leqNgt; apply/card_le1_eqP => u v uA vA.
+  wlog suff eq_x : u uA / u = x; first by rewrite [v]eq_x // [u]eq_x.
+  rewrite -!disjoint_has in nAs1 nAs2.
+  move/subAs : (uA). rewrite def_s !(mem_cat,mem_rcons,inE).
+  by rewrite (disjointFl nAs1) // (disjointFl nAs2) // !orbF => /eqP. }
+case/split_find def_s2 : {-}s2 _ _ / hasAs2 => [/= y s21 s22 yA nAs21].
+rewrite -!disjoint_has in nAs1 nAs21.
+have [eq_xy|xDy] := eqVneq x y.
+- subst y; have sub_A_s2 : {subset A <= s2}. 
+  { move=> u uA; move/subAs : (uA).
+    rewrite def_s mem_cat mem_rcons inE (disjointFl nAs1) ?orbF //.
+    by case/predU1P => [->|//]; rewrite def_s2 mem_cat mem_rcons mem_head. }
+  have size_s2 : size s2 < size s.
+  { by rewrite def_s size_cat size_rcons addSn ltnS leq_addl. }
+  have [u[v[p1[p2[p3[uA vA uDv def_s2' disAp2]]]]]] := IH s2 size_s2 sub_A_s2. 
+  by exists u,v,(rcons s1 x ++ p1),p2,p3; split; rewrite // def_s def_s2' /= -catA. 
+- exists x,y,s1,s21,s22; rewrite disjoint_sym nAs21; split => //.
+  by rewrite def_s def_s2 -!cats1 /= -!catA.
+Qed.
+
+(* [0 < #|A|] is required sind hypermaps cant have isolated vertices *)
+Lemma plane_add_node_simple (G : sgraph) (g : plane_embedding G) s (A : {set G}) x :
+  x \in A -> sface g s -> {subset A <= s} -> inhabited (plane_embedding (add_node G A)).
+Proof.
+have [gt1A _ {x} face_s subA|le1A xA] := ltnP 1 #|A|; last first.
+- have/eqP eq_A : A == [set x]; last subst A.
+  { by apply/eq_set1P; split => // y yA; apply: (card_le1_eqP le1A). }
+  move=> face_s subXs; have x_s : x \in s by apply: subXs; rewrite in_set1.
+  have [i s' rot_i] := rot_to x_s; move/(rot_face i): face_s; rewrite rot_i.
+  by case/plane_add_node1. 
+- have : exists x y s1 s2 i, 
+    rot i s = x :: s1 ++ y :: s2 /\ x != y /\ [disjoint A & s2] /\ x \in A /\ y \in A.
+  { have [x [y [s1 [s2 [s3 [xA yA xDy def_s disA]]]]]] := foo gt1A subA.
+    exists y,x,(s3++s1),s2,(size (s1 ++ x :: s2)). 
+    by rewrite def_s -!cat_cons catA rot_size_cat eq_sym /= -catA. }
+  move => [x] [y] [s1] [s2] [i] [rot_i [xDy [disjA [xA yA]]]].
+  move/(rot_face i) in face_s; rewrite rot_i in face_s. 
+  have [|//|//|//] := @plane_add_node _ _ _ _ _ _ A xDy face_s.
+  move=> a aA; move: (aA) => /subA. 
+  rewrite -(mem_rot i) rot_i !(inE,mem_cat,mem_rcons) (disjointFr disjA) //.
+  by rewrite orbF => /or3P[->|->|->].
+Qed.
+
+(** Deleting vertex from a 2-connected plane graph yields a plane
+graph with a face containing all the neighbors of the deleted node. *)
+
+Section PlaneDelVertex.
+Variables (G : sgraph) (g : plane_embedding G) (x : G).
+
+Hypothesis connG : 2.-connected G.
+
+Let D := emb_map g.
+Let d := emb_inv (emb_embedding g) x.
+Let G' := induced [set~ x].
+Let D' := del_node d.
+Let N := fclosure edge (cnode d).
+
+Lemma del_vertex_emb_proof (z : D') : g (val z) \in [set~ x].
+Proof.
+case: z => z Hz /=; rewrite !inE. 
+apply: contraNneq Hz => E. apply: mem_closure. 
+by rewrite inE /d -E (emb_vertex (emb_embedding g)) (emb_invK).
+Qed.
+
+Definition del_vertex_emb (z : D') : G' := 
+  Sub (g (val z)) (del_vertex_emb_proof z).
+
+Let nxxF (z : D) : node z == z = false.
+Proof.
+have := kconnected_degree (g z) connG; rewrite ltnNge. 
+apply: contraNF => /eqP /(@order_le_fix _ node 0 z).
+exact/leq_trans/emb_degree/emb_embedding.
+Qed.
+
+Hypothesis simpleD : forall x y : D, x != y -> cnode x y -> ~~ cnode (edge x) (edge y).
+
+Lemma del_vertex_emb_embedding : embedding del_vertex_emb.
+Proof.
+have [plainD surj_g vertex_g edge_g] := emb_embedding g.
+rewrite -/D in plainD vertex_g edge_g.
+split.
+- exact/del_node_plain.
+- move => y. have [y0 g_y0] := codomP (surj_g (val y)); apply/codomP.
+  have Hy : ~~ cnode d y0. 
+    by apply: contraTN (valP y); rewrite !inE negbK cnodeC vertex_g -g_y0 emb_invK.
+  have [/del_node_neighbor1|y0N]:= boolP (y0 \in N).
+  + case/(_ _ _ _ _)/Wrap => // ny0N. exists (Sub (node y0) ny0N). 
+    by apply: val_inj; rewrite /= g_y0; apply/eqP; rewrite -vertex_g -cnode1r.
+  + by exists (Sub y0 y0N); exact: val_inj. 
+- by move=> d1 d2; rewrite del_node_cnode vertex_g /del_vertex_emb -val_eqE.
+- by move=> d1 d2; rewrite del_node_adjn // edge_g /del_vertex_emb.
+Qed.
+
+Definition del_vertex_plane_embedding :=
+  Build_plane_embedding del_vertex_emb_embedding (del_node_planar d (emb_planar g)).
+
+Let g' := del_vertex_plane_embedding.
+
+
+Lemma del_vertex_neighbor_face : 
+  exists2 s : seq G', sface g' s & {subset N(x) <= map val s}.
+Proof.
+have fdN : face d \notin N. 
+{ apply: wheel_proof => //.
+  - apply: plane_emb_plain.
+  - apply: plane_emb_loopless. }
+set d' : D' := Sub (face d) fdN; set s := [seq g' i | i <- orbit face d'].
+have H := @neighbor_face_aux D d _ _ simpleD nxxF. 
+exists s; first by exists d'. 
+move => z; rewrite inE /s -map_comp => xz. apply/mapP. 
+rewrite -[x](pinvK g) -[z](pinvK g) -plane_emb_edge -[pinv g x]/d in xz.
+have cycleD : forall x y : D, x != y -> cface x y -> ~~ cnode x y.
+{ apply: two_connected_cyle => //. 
+  apply: two_connected_avoid_one (emb_embedding g) connG.
+  - exact: plane_emb_plain.
+  - exact: plane_emb_loopless.
+  - exact: emb_planar. }
+have := @del_node_adjn_face 
+          D d (plane_emb_plain g) (plane_emb_loopless g) simpleD nxxF cycleD.
+move=> /(_ _ xz) => -[dz]; rewrite [wheel_proof _ _ _ _ _ ](bool_irrelevance _ fdN).
+case => D1 D2. 
+by exists dz => //=; apply/eqP; rewrite -[z](pinvK g) -plane_emb_vertex cnodeC.
+Qed.
+
+End PlaneDelVertex.
+
+Arguments skip_hom [T] a [f] _.
+
+Lemma subgraph_embedding (G H : sgraph) (D : hypermap) (g : D -> H) : 
+  subgraph G H -> no_isolated G -> embedding g -> 
+  exists (D' : hypermap) (g' : D' -> G), embedding g' /\ genus D' <= genus D.
+Proof.
+case => h inj_h hom_h no_isoG emb_g.
+have plainD := emb_plain emb_g.
+pose V := h @: G.
+pose h' (x : H) : option G :=
+  if boolP (x \in codom h) is AltTrue b then Some (iinv b) else None.
+pose r := [rel u v : H | 
+           if (h' u, h' v) is (Some u', Some v') then u' -- v' else false].
+pose p := [pred x : D | r (g x) (g (edge x))].
+pose e := frestrict (skip_hom p edgeI).
+pose n := frestrict (skip_hom p nodeI).
+pose f := finv n \o finv e.
+have can3 : cancel3 e n f.
+{ by move=> x; rewrite /f/= f_finv ?finv_f //; apply/frestrict_inj/skip_inj. }
+pose D' := Hypermap can3. 
+have cl_p : fclosed edge p.
+{ move=> x y /eqP <- {y}. rewrite !inE plain_eq // /h'.
+  case: {-}_ / boolP => [gx_h|gxNh]; case: {-}_ / boolP => [gex_h|gexNh] => //.
+  by rewrite sgP. }
+have eE (x : D') : val (edge x) = edge (val x).
+{ rewrite val_frestrict skip1 // -(fclosed1 cl_p); exact: (valP x). }
+have imG : forall x : D', g (val x) \in codom h. 
+{ move=> x. have:= valP x. rewrite /p/=/h'. by case: {-}_ / boolP. }
+pose g' (x : D') := iinv (imG x).
+have leq_genus : genus D' <= genus D by apply: sub_genus => x; rewrite val_frestrict.
+suff emb_g' : @embedding G D' g' by exists D',g'. 
+have cnE (x y : D') : cnode x y = (g' x == g' y).
+{ rewrite fconnect_frestrict fconnect_skip //; try apply: valP.
+  rewrite /g' -(inj_eq inj_h) !f_iinv; exact/emb_vertex. }
+split => //.
+- apply/plainP => x _; split; last by rewrite -val_eqE eE plain_neq.
+  by apply: val_inj; rewrite !eE plain_eq.
+- move=> x; have [y xy] := no_isoG x.
+  move/hom_h: (xy); rewrite inj_eq // sg_edgeNeq // => /(_ isT) hx_hy.
+  have/codomP [dx hx_dx] := emb_surj emb_g (h x).
+  have/codomP [dy hy_dy] := emb_surj emb_g (h y).
+  move: hx_hy; rewrite hx_dx hy_dy -(emb_edge emb_g).
+  case/exists_inP => [dz]; rewrite !inE => cn_xz cn_yz. 
+  suff pz : p dz.
+  { apply/codomP; exists (Sub dz pz). apply: inj_h. rewrite f_iinv /=. 
+    by rewrite hx_dx (rwP eqP) -(emb_vertex emb_g). }
+  rewrite !(emb_vertex emb_g) in cn_xz cn_yz.
+  rewrite /p/=/h' altT -?(eqP cn_xz) -?hx_dx ?codom_f // => codom_x.
+  rewrite altT -?(eqP cn_yz) -?hy_dy ?codom_f // => codom_y.
+  by rewrite !iinv_f.
+- move=> x y; apply/exists_inP/idP => [[z]|].
+  + rewrite !inE !cnE /g' => /eqP-> /eqP->; have:= valP z; rewrite /p/=/h'. 
+    case : {-}_ /boolP => // gz_h; case : {-}_ /boolP => // gez_h.
+    move: (imG (e z)); rewrite /= eE => gez_h'.
+    by rewrite (bool_irrelevance gz_h (imG z)) (bool_irrelevance gez_h gez_h'). 
+  + move=> g'_xy.
+    move/hom_h : (g'_xy); rewrite inj_eq // (sg_edgeNeq g'_xy) => /(_ isT) hg'_xy.
+    move: (hg'_xy); rewrite !f_iinv => g_xy. 
+    move: (g_xy); rewrite -(emb_edge emb_g) => /exists_inP[z].
+    rewrite !inE => cn_xz cn_yz. 
+    suff pz : p z. 
+    { exists (Sub z pz); rewrite inE fconnect_frestrict fconnect_skip // ?eE //; try apply: valP.
+      by rewrite -(fclosed1 cl_p). }
+    rewrite !(emb_vertex emb_g) in cn_xz cn_yz.
+    rewrite /p/=/h' altT -(eqP cn_xz) ?imG // => codom_x.
+    rewrite altT -(eqP cn_yz) ?imG // => codom_y.
+    move: g'_xy; rewrite /g'; move: (imG x) (imG y) => P1 P2.
+    by rewrite (bool_irrelevance P1 codom_x) (bool_irrelevance P2 codom_y).
+Qed.
+
+Lemma subgraph_plane_embedding (G H : sgraph) : 
+  subgraph G H -> no_isolated G -> 
+  plane_embedding H -> inhabited (plane_embedding G).
+Proof.
+move=> sub_G_H no_isoG [D g emb_g] planarD. 
+have [D'[g' [emb_g']]] := subgraph_embedding sub_G_H no_isoG emb_g.
+rewrite (eqP planarD) (leqn0) -/(planar D') => planarD'.
+by exists; apply: Build_plane_embedding emb_g' planarD'.
+Qed.
+
+(** Removing parallel edges *)
+
+Section RemoveParallelEdges.
+Variables (G : sgraph).
+
+Lemma remove_parallel (D : hypermap) (g : D -> G) (emb_g : embedding g) : 
+  exists (D' : hypermap) (g' : D' -> G), 
+    [/\ simple_hmap D', embedding g' & genus D' <= genus D].
+Proof.
+elim/card_ind : D g emb_g => D IH g emb_g.
+pose b := [exists x : D, exists y, [&& x != y, cnode x y & cnode (edge x) (edge y)]].
+have [|simpleD] := boolP b; rewrite /b; last first.
+{ exists D, g; split => // x y xDy n_x_y. 
+  by move: simpleD => /existsPn /(_ x) /exists_inPn /(_ _ xDy); rewrite n_x_y. }
+move=> /existsP [x /exists_inP [y xDy /andP[n_x_y n_ex_ey]]].
+have plainD : plain D by apply: emb_plain emb_g.
+have exF : edge x != x by rewrite plain_neq.
+pose D' := @WalkupE (WalkupF x) (Sub (edge x) exF).
+pose g' (z : D') := g (val (val z)).
+suff emb_g' : embedding g'.
+{ have leD : #|D'| < #|D|.
+    by rewrite /D' -card_S_Walkup /WalkupF /= card_sig max_card.
+  have [D'' [g'' [D1 D2 D3]]] := IH _ leD _  emb_g'. 
+  exists D'', g''; split => //; apply: leq_trans D3 _. 
+  exact: leq_trans (le_genus_WalkupE _) (le_genus_WalkupF _). }
+rewrite eq_sym in xDy.
+have plain_eq := plain_eq plainD.
+have yDex : y != edge x. 
+{ apply: contraNneq (emb_loopless emb_g) => y_ex. by apply/existsP; exists x; rewrite -y_ex. }
+have inDpf (z : D) (zDx : z != x) (zDex : z != edge x) : 
+  (Sub z zDx) != Sub (edge x) exF :> WalkupF x by rewrite -val_eqE.
+pose inD' (z:D) (zDx : z != x) (zDex : z != edge x) : D' := 
+  Sub (Sub z zDx) (inDpf z zDx zDex).
+have plainD' : plain D'.
+{ apply/plainP => u _; case: u => [[u U1] U2']. 
+  have U2 : @edge D u != x by rewrite -!val_eqE /= -(inj_eq edgeI) /= plain_eq in U2'. 
+  split.
+  + do 2 apply: val_inj; rewrite /= ![sval (if _ then _ else _)]fun_if.
+    rewrite -!val_eqE /= ![sval (if _ then _ else _)]fun_if.
+    rewrite plain_eq !eqxx /=. 
+    by rewrite (negbTE U2) plain_eq (negbTE U1).
+  + rewrite -!val_eqE /= ![sval (if _ then _ else _)]fun_if /=.
+    by rewrite -!val_eqE /= plain_eq !eqxx (negbTE U2) plain_neq. }
+split => //.
+- (* chose [y] (resp. [edge y]) if [x]/[edge x] is the preimage *)
+  move=> v; have [z g_z] := codomP (emb_surj emb_g v).
+  have [xVex|] := boolP (z \in pred2 x (edge x)).
+  + case/pred2P : xVex => ?; subst z v; apply/codomP.
+    * by exists (inD' _ xDy yDex); apply/eqP; rewrite -(emb_vertex emb_g).
+    * rewrite -(inj_eq edgeI) in xDy; rewrite -(inj_eq edgeI) plain_eq in yDex.
+      by exists (inD' _ yDex xDy); apply/eqP; rewrite -(emb_vertex emb_g).
+  + rewrite !inE negb_or => /andP [zDx zDex]. by apply/codomP; exists (inD' _ zDx zDex).
+- move => u v. by rewrite !walkup.fconnect_skip /= (emb_vertex emb_g).
+- move => u v. 
+  have edge_val (z : D') : @edge D (val (val z)) = val (val (edge z)).
+  { rewrite /= ![sval (if _ then _ else _)]fun_if /= -!val_eqE /=.
+    rewrite !plain_eq !eqxx ifF // -(inj_eq edgeI) plain_eq. 
+    by move: (valP z); rewrite -val_eqE => /=/negbTE->. }
+  suff -> : adjn u v = @adjn D (val (val u)) (val (val v)) by apply: emb_edge.
+  apply/exists_inP/exists_inP => -[z]; rewrite !inE.
+  + by rewrite !walkup.fconnect_skip; exists (val (val z)); rewrite // edge_val.
+  + have [xVex|] := boolP (z \in pred2 x (edge x)).
+    * wlog -> : z u v {xVex} / z = x => [W|].
+      { case/pred2P : xVex => z_ex ; first exact: W.
+        move=> n_u n_v. move: (W (edge z) v u); rewrite {1}z_ex !plain_eq.
+        case => // z'. exists (edge z') => //. by rewrite (geometry.plain_eq plainD'). }
+      exists (inD' _ xDy yDex); rewrite !inE !walkup.fconnect_skip //=.
+        exact: connect_trans n_x_y.
+      rewrite fun_if -val_eqE /= plain_eq !eqxx -(inj_eq edgeI) plain_eq (negbTE yDex).
+      exact: connect_trans n_ex_ey.
+    * rewrite inE negb_or => /andP[zDx zDex] n_u_z n_v_ez.
+      by exists (inD' _ zDx zDex); rewrite !inE !walkup.fconnect_skip // -edge_val.
+Qed.
+
+Lemma le_genus_planar (D D' : hypermap) : genus D' <= genus D -> planar D -> planar D'.
+Proof. rewrite /planar -!leqn0. exact: leq_trans. Qed.
+
+Lemma simple_embedding (g : plane_embedding G) : 
+  exists g' : plane_embedding G, simple_hmap (emb_map g').
+Proof.
+case: g => D g emb_g planarD.
+have [D' [g' [simpleD' emb_g' le_genus]]] := remove_parallel emb_g.
+have planarD' : planar D' by exact: le_genus_planar planarD.
+by exists (Build_plane_embedding emb_g' planarD').
+Qed.
+
+End RemoveParallelEdges.
+
+
+(** ** Obtaining plane embeddings for smerge2 *)
+Section smerge_plane_embedding.
+Variables (G : sgraph) (x y : G) (g : plane_embedding G).
+
+Local Notation "'@cnode[' G ]" := (fconnect (@node G)) (at level 1, format "'@cnode[' G ]").
+Local Notation "'@cface[' G ]" := (fconnect (@face G)) (at level 1, format "'@cface[' G ]").
+Local Notation "'@adjn[' G ]" := (@adjn G) (at level 1, format "'@adjn[' G ]").
+
+Let G' := smerge2 G x y.
+Let D := emb_map g.
+
+Section embeddging.
+Variables (dx dy : D).
+Let D' := merge D dx dy.
+
+Hypothesis xNy : x -- y = false.
+Hypothesis xDy : x != y.
+Hypothesis g_dx : g dx = x.
+Hypothesis g_dy : g dy = y.
+
+Let plainD' : plain D'. Proof. by apply: plane_emb_plain. Qed.
+Let dxDdy : dx != dy. Proof. by apply: contra_neq xDy; congruence. Qed.
+
+Definition g' (dz : D') := 
+  if @boolP ((g dz) == y) is AltFalse p then Sub (g dz) p else (Sub x xDy) : G'.
+
+Lemma embedding_g' : embedding g'.
+Proof.
+have n_dxy : ~~ @cnode[D] dx dy. 
+  by rewrite plane_emb_vertex g_dx g_dy.
+have llD : loopless D by apply plane_emb_loopless.
+have nAdydy : ~~ @adjn[D] dx dy by rewrite plane_emb_edge g_dx g_dy xNy.
+have llD' : loopless D' by apply merge_loopless.
+have subDD' : subrel @cnode[D] @cnode[D'] by apply: switch_subrel.
+have adjnD' (d1 d2 : D) : g d1 = y -> @adjn[D'] d1 d2 = @adjn[D] d2 dx || @adjn[D] d2 dy.
+{ move => g1_y. apply: adjn_merge1 => //. by rewrite (plane_emb_vertex) g_dy g1_y. }
+have adjnD'' (d1 d2 : D) : g d1 = x -> @adjn[D'] d1 d2 = @adjn[D] d2 dx || @adjn[D] d2 dy.
+{ move => g1_y. rewrite /D' adjn_mergeC orbC. apply: adjn_merge1 => //; first by rewrite eq_sym.
+  by rewrite cnodeC. by rewrite adjnC. 
+  by rewrite (plane_emb_vertex) g_dx g1_y. }
+split => //.
+- case => z zDy. have [z0 g_z0] := codomP (plane_emb_surj g z).
+  by apply/codomP; exists z0; apply: val_inj; rewrite /g'/= -g_z0 altF.
+- move => d1 d2; rewrite cnode_merge // !plane_emb_vertex /g'.
+  case: {-}_ / boolP => [/eqP g1_y|g1Dy]; case: {-}_ / boolP => [/eqP g2_y|g2Dy].
+  all: rewrite -val_eqE /= ?g1_y ?g2_y ?g_dx ?g_dy ?eqxx //.
+  all: by rewrite ?[y == _]eq_sym ?[_ == x]eq_sym ?(negbTE xDy) ?(negbTE g2Dy) ?(negbTE g1Dy).
+- move => d1 d2. rewrite /g'. 
+  case: {-}_ / boolP => [/eqP g1_y|g1Dy]; case: {-}_ / boolP => [/eqP g2_y|g2Dy].
+  + rewrite sgP. have n12 : @cnode[D] d1 d2 by rewrite (plane_emb_vertex) g1_y g2_y.
+    apply: contraNF llD' => /exists_inP [z]; rewrite !inE => A1 A2. 
+    rewrite cnodeC in A1. apply/existsP; exists z. 
+    apply: connect_trans A2. apply: connect_trans A1 _. by apply: switch_subrel n12.
+  + rewrite adjnD' //. rewrite /edge_rel/= eqxx andbF /= !plane_emb_edge g_dx g_dy.
+    case: (eqVneq (g d2) x) => //= ->. by rewrite sgP.
+  + rewrite adjnC // adjnD' // !plane_emb_edge g_dx g_dy [RHS]/edge_rel/= !eqxx andbF /=.
+    case: (eqVneq (g d1) x) => //= ->. by rewrite sgP.
+  + rewrite /edge_rel/=.
+    have [|] := boolP ((g d1 == x) || (g d2 == x)).
+    * case: (eqVneq (g d1) x) => [g1x|g1Dx]; case: (eqVneq (g d2) x) => [g2x|g2Dx] => //= _.
+      -- rewrite g1x g2x sgP adjn_loopless //. apply: subDD'.
+         by rewrite plane_emb_vertex g1x g2x.
+      -- by rewrite adjnD'' // !plane_emb_edge g_dx g_dy.
+      -- by rewrite adjnC // adjnD'' // !plane_emb_edge g_dx g_dy.
+    * rewrite negb_or => /andP[g1Dx g2Dx]; rewrite (negbTE g1Dx) (negbTE g2Dx) /=.
+      by rewrite adjn_merge2 // ?(plane_emb_vertex) ?g_dx ?g_dy // plane_emb_edge.
+Qed.
+
+Lemma planar1 : ~~ connect (--) x y -> planar D'.
+Proof. 
+move => nc_xy; apply: merge_planar; last exact: emb_planar.
+by rewrite (emb_gcomp (emb_embedding g)) g_dx g_dy nc_xy.
+Qed.
+
+End embeddging.
+
+(* simple version - taking any preimages of [x] and [y] *)
+Lemma smerge_plane_embedding_disconnected :
+  ~~ connect (--) x y -> inhabited (plane_embedding (smerge2 G x y)).
+Proof.
+move => n_xy. 
+have [dx /esym g_dx] := codomP (plane_emb_surj g x).
+have [dy /esym g_dy] := codomP (plane_emb_surj g y).
+have xDy : x != y by apply: contraNneq n_xy => ->.
+have emb_g' : embedding (@g' dx dy xDy).
+ by apply: embedding_g' => //; apply: contraNF n_xy; exact: connect1. 
+constructor; apply: Build_plane_embedding emb_g' _.
+exact: planar1.
+Qed.
+
+Hint Extern 0 (embedding _) => exact: emb_embedding : core. (* TODO: move up *)
+
+Lemma face_connect dx dy : @cface[D] dx dy -> connect (--) (g dx) (g dy).
+Proof. by rewrite -emb_gcomp //; apply: gcompF. Qed.
+
+Lemma smerge_plane_embedding_disconnected' xs ys :
+  ~~ connect (--) x y -> sface g (x :: xs) -> sface g (y :: ys) -> 
+  exists (g' : plane_embedding (smerge2 G x y)) s', 
+    sface g' s' /\ {subset [predD1 x :: xs ++ ys & y] <= map val s'}.
+Proof.
+move => n_xy. 
+case => dx. move: (fconnect_orbit face dx).
+case: (orbit_case face dx) => dxs -> /= f_dx [/esym g_dx def_xs].
+case => dy. move: (fconnect_orbit face dy).
+case: (orbit_case face dy) => dys -> /= f_dy [/esym g_dy def_ys].
+
+have xDy : x != y by apply: contraNneq n_xy => ->.
+have dxDdy : dx != dy by apply: contra_neq xDy => E; rewrite -g_dx E g_dy.
+have emb_g' : embedding (@g' dx dy xDy).
+ by apply: embedding_g' => //; apply: contraNF n_xy; exact: connect1. 
+pose D' := merge D dx dy.
+have planarD' : planar D' by apply: planar1.
+have fI := @faceI D.
+have fxy : @cface[D'] (finv face dy) (finv face dx).
+{ rewrite fconnect_switched // ?(inj_eq (finv_inj fI)) 1?eq_sym //.
+  rewrite (@cface1 D) (@cface1r D) !f_finv // cfaceC. 
+  apply: contraNN n_xy; rewrite -g_dx -g_dy. exact: face_connect. }
+have subDD' : subrel @cface[D] @cface[D'].
+{ apply switch_subrel; rewrite // -fconnect_switched //. 
+  by rewrite ?(inj_eq (finv_inj fI)) 1?eq_sym. }
+pose h := Build_plane_embedding emb_g' planarD'; exists h.
+exists (map h (@orbit D' face (finv (@face D) dx))); split; first by exists (finv face dx).
+move => z /andP [zDy /= Hz].
+suff: exists2 dz : D, g dz = z & @cface[D'] (finv face dx) dz.
+{ case => dz g_dz; rewrite fconnect_orbit -map_comp => orb_z.
+  by apply/mapP; exists dz => //=; rewrite /g' altF ?g_dz. }
+move: Hz; rewrite !(inE,mem_cat) def_xs def_ys => /or3P[/eqP -> {zDy z}||].
+- exists dx => //. rewrite cfaceC. apply: connect_trans fxy. rewrite cfaceC.
+  apply: connect1. by rewrite /= eqxx f_finv.
+- case/mapP => dz Hdz /esym g_dz; exists dz => //. apply: subDD'.
+  by rewrite cface1 f_finv // f_dx inE Hdz.
+- case/mapP => dz Hdz /esym g_dz; exists dz => //; rewrite cfaceC. 
+  apply: connect_trans fxy. apply: subDD'. 
+  by rewrite cfaceC cface1 f_finv // f_dy inE Hdz. 
+Qed.
+
+Lemma smerge_plane_embedding_face s : x \in s -> y \in s -> x != y -> ~~ x -- y -> sface g s -> 
+  inhabited (plane_embedding (smerge2 G x y)).
+Proof.
+move => x_s y_s xDy xNy []; rewrite -/D => dz def_s.
+rewrite def_s in x_s y_s.
+have [dx fdx /esym g_dx] := mapP x_s.
+have [dy fdy /esym g_dy] := mapP y_s.
+pose D' := merge D dx dy.
+have emb_g' : embedding (@g' dx dy xDy).
+ apply: embedding_g' => //. exact: negbTE.
+constructor; apply: Build_plane_embedding emb_g' _.
+apply: merge_planar; last exact: emb_planar.
+rewrite plane_emb_vertex g_dx g_dy (negbTE xDy) /=.
+rewrite -!fconnect_orbit in fdx fdy.
+by rewrite (connect_trans _ fdy) // cfaceC.
+Qed.
+
+End smerge_plane_embedding.
+
+
+
+
+
+(** ** Non-planarity proofs *)
+
+Lemma connected_n_comp1 (G : sgraph) (x0 : G) : 
+  connected [set: G] -> n_comp (--) G = 1.
+Proof.
+move/connectedTE => conG. 
+have E: connect (--) x0 =i G by move => ?; rewrite inE (conG x0).
+rewrite -(eq_n_comp_r E) n_comp_connect //. exact: sconnect_sym.
+Qed.
+
+Lemma n_comp_Knm n m : n_comp (--) 'K_n.+1,m.+1 = 1.
+Proof.
+set K := 'K__,_; pose x : K := inl ord0.
+suff S : connect (--) x =i K. 
+  by rewrite -(eq_n_comp_r S) n_comp_connect //; exact: sconnect_sym.
+move => y; rewrite !inE. case: y => [y|y]; last exact: connect1.
+by apply: (@connect_trans _ _ (inr ord0)); apply: connect1.
+Qed.
+
+Lemma n_comp_Kn n : n_comp (--) 'K_n.+1 = 1.
+Proof.
+apply: connected_n_comp1 (ord0 : 'K_n.+1) _.
+apply: (@connected_center _ (ord0 : 'K_n.+1)) => // j _. 
+by have [-> //|?] := eqVneq ord0 j; apply: connect1.
+Qed.
+
+Lemma K5nonplanar : ~ inhabited (plane_embedding 'K_5).
+Proof.
+move => [/simple_embedding [[D g emb_g planarD] /= simpleD]]. 
+suff : Euler_lhs D - Euler_rhs D > 0 by rewrite -genus_gt0 (eqP planarD).
+pose F := fcard face D.
+have cD : #|D| = 20 by rewrite (card_emb emb_g simpleD) card_edge_Kn.
+have -> : Euler_lhs D = 22.
+  by rewrite /Euler_lhs (emb_n_comp emb_g) n_comp_Kn cD. 
+have -> : Euler_rhs D = 15 + F. 
+{ rewrite /Euler_rhs (emb_ncard emb_g) (emb_ecard emb_g simpleD).
+  by rewrite card_ord card_edge_Kn. }
+suff: F < 7 by case: F => [|[|[|[|[|[|[|]]]]]]].
+apply: contra_eqT cD. rewrite eqn_leq negb_and -!ltnNge ltnS => F7.
+apply/orP;left; rewrite (sum_roots_order faceI).
+have bound : {in froots (@face D), forall x, 2 < arity x}.
+{ apply:in1W => x; apply: emb_arity3 emb_g simpleD _ _ => {x} x.
+  exact: leq_trans (deg_Kn _). }
+apply: leq_trans (leq_sum _ bound); rewrite sum_nat_const.
+have -> : #|froots (@face D)| = F by apply: eq_card => z; rewrite !inE andbT.
+by apply: (@leq_trans (7 * 3)); rewrite // leq_mul2r F7.
+Qed.
+
+Lemma K33nonplanar : ~ inhabited (plane_embedding 'K_3,3).
+Proof.
+move => [/simple_embedding [[D g emb_g planarD] /= simpleD]]. 
+suff : Euler_lhs D - Euler_rhs D > 0 by rewrite -genus_gt0 (eqP planarD).
+pose F := fcard face D.
+have cD : #|D| = 18 by rewrite (card_emb emb_g simpleD) card_edge_Knm.
+have -> : Euler_lhs D = 20. 
+  by rewrite /Euler_lhs (emb_n_comp emb_g) n_comp_Knm cD. 
+have -> : Euler_rhs D = 15 + F. 
+{ rewrite /Euler_rhs (emb_ncard emb_g) (emb_ecard emb_g simpleD).
+  by rewrite card_sum card_ord card_edge_Knm. }
+suff : F <= 4 by case: F => [|[|[|[|[|]]]]].
+apply: contra_eqT (cD); rewrite -ltnNge eqn_leq negb_and -ltnNge => F5.
+apply/orP;left; rewrite (sum_roots_order faceI).
+suff bound : {in froots (@face D), forall x, 3 < arity x}.
+{ apply: leq_trans (leq_sum _ bound) ; rewrite sum_nat_const.
+  have -> : #|froots (@face D)| = F by apply: eq_card => z; rewrite !inE andbT.
+  by apply: (@leq_trans (5 * 4)); rewrite // leq_mul2r F5. }
+move=> x _; rewrite ltn_neqAle (emb_arity3 emb_g simpleD) ?andbT 1?eq_sym.
+- have/even_cycle_Knm := emb_face_cycle emb_g x.
+  by apply: contraNneq; rewrite size_map size_orbit => ->.
+- move=> y. exact: leq_trans (deg_Knm _).
+Qed.
+
+
+(* TOTHINK: Finish or remove 
+
+(** We show that every simple graph without isolated vertices can be
+represented by a (plain) hypermap. This is mostly a sanity check, no
+part of the proof relies in this construction *)
+
+Module ExampleEmbedding.
+Section Ex.
+Variables (G : sgraph). 
+
+Definition edart := { p : G * G | p.1 -- p.2 }.
+
+Let swap (p : G * G) := (p.2,p.1).
+
+Lemma eedge_proof (e : edart) : (swap (val e)).1 -- (swap (val e)).2.
+Proof. case: e => /= [x y]; by rewrite sgP. Qed.
+
+Definition eedge (e : edart) : edart := Sub (swap (val e)) (eedge_proof e).
+
+Lemma eedgeI : injective eedge.
+Proof. 
+move => [[x y] /= [xy]] [[x' y'] /= [xy']]; case => ? ?. by apply: val_inj; subst.
+Qed.
+
+Let N (p : edart) : seq edart := enum [pred q | (val p).1 == (val q).1].
+
+Let mem_N (x y : edart) : y \in N x = ((val x).1 == (val y).1).
+Proof. by rewrite mem_enum inE. Qed.
+
+Let Nxx x : x \in N x. Proof. by rewrite mem_N. Qed.
+
+Definition enode (p : edart) : edart := next (N p) p.
+
+Lemma enodeI : injective enode.
+Proof. 
+move => p1 p2 E. rewrite /enode in E.
+suff S : N p1 = N p2.
+{ move: E. rewrite S. apply/can_inj/prev_next. exact: enum_uniq. }
+suff S: N p1 =i N p2 by apply: eq_enum => z; rewrite -mem_enum S mem_enum.
+have V x : (val x).1 = (val (next (N x) x)).1 by apply/eqP; rewrite -mem_N mem_next.
+have P : (val p1).1 == (val p2).1 by rewrite V E eq_sym -mem_N mem_next Nxx.
+by move => z; rewrite !mem_N (eqP P).
+Qed.
+
+Definition eface : edart -> edart := finv enode \o finv eedge.
+
+Lemma emb_can3 : cancel3 eedge enode eface.
+Proof. 
+move => x; rewrite /eface /= finv_f ?f_finv //; [exact: enodeI|exact: eedgeI].
+Qed.
+
+Definition default_embedding := Hypermap emb_can3.
+
+Definition efun (e : default_embedding) : G := (val e).1.
+
+Let cnodeN (d1 d2 : default_embedding) : cnode d1 d2 = (d2 \in N d1).
+have fcN d : fcycle (next (N d)) (N d) by apply/cycle_next/enum_uniq.
+apply/idP/idP.
++ case/connectP => p; elim: p d1 => /= [d1 _ -> //|d p IHp d1 /andP [nd1 pth_p] lst_p].
+  have {pth_p lst_p IHp} IH := IHp _ pth_p lst_p.
+  admit. (* same as above *)
++ admit.
+Admitted.
+
+Hypothesis no_iso : forall x : G, exists y : G, x -- y.
+
+Lemma efun_emb : embedding efun.
+Proof.
+split.
+- apply/plainP => [[[x y] H] _];split; first exact: val_inj.
+  rewrite -val_eqE /=. apply: contraTneq H => [[-> _]]. by rewrite /= sgP.
+- move => x; have [y xy] := no_iso x. 
+  apply/mapP; exists (Sub (x,y) xy) => //. by rewrite mem_enum.
+- move => d1 d2. by rewrite cnodeN mem_N.
+- move => [[x y] /= xy] [[x' y'] /= xy']; rewrite /adjn /efun /=.
+  apply/exists_inP/idP => [[[[z z'] /= zz']]|xx'].
+  + by rewrite !inE !cnodeN !mem_N /= => /eqP-> /eqP->.
+  + exists (Sub (x,x') xx'); by rewrite inE cnodeN mem_N.
+Qed.
+
+End Ex.
+End ExampleEmbedding.
+*)

--- a/theories/hcycle.v
+++ b/theories/hcycle.v
@@ -1,0 +1,311 @@
+From mathcomp Require Import all_ssreflect.
+
+Require Import edone preliminaries digraph sgraph.
+From fourcolor Require Import hypermap geometry jordan color coloring combinatorial4ct.
+Require Import hmap_ops.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Definition kconnected_map (k : nat) (G : hypermap) := 
+  k < fcard node G /\ 
+  forall A : pred G, #|A| < k -> 
+    {in [predC fclosure node A]&, forall x y, connect (restrict [predC fclosure node A] glink) x y}.
+
+Lemma closed_connect (T : finType) (e : rel T) (A : pred T) : 
+  closed e A -> {in A, subrel (connect e) (connect (restrict A e))}.
+Proof.
+move => clA x xA y.
+case/connectP => p; elim: p x xA => [x _ _ -> //|z p IHp /= x xA /andP [xz pth_p] lst_p].
+have zA: z \in A by rewrite -(clA _ _ xz).
+by apply: connect_trans (IHp _ zA pth_p lst_p); apply:connect1; rewrite /= xA zA.
+Qed.
+
+Lemma in_connect_sym (T : finType) (e : rel T) (A : pred T) : 
+  closed e A -> connect_sym e -> {in A&, connect_sym (restrict A e)}.
+Proof. 
+move => clA sym_e x y xA yA.
+wlog suff : x y xA yA / connect (restrict A e) x y -> connect (restrict A e) y x.
+{ by move => W; apply/idP/idP; apply: W. }
+case/connectP => p; elim: p x xA => /= [x _ _ -> //| z p IHp x xA].
+rewrite -!andbA => /and4P [_ zA x_z pth_p lst_p].
+have {pth_p lst_p} IH := IHp _ zA pth_p lst_p. apply: connect_trans IH _.
+have := (connect1 x_z); rewrite sym_e; exact: closed_connect.
+Qed.
+
+Lemma sub_restrict T (e1 e2 : rel T) (A : pred T) : 
+  {in A&, subrel e1 e2} -> subrel (restrict A e1) (restrict A e2).
+Proof. move => sub x y /=/andP[/andP [xA yA] xy]. by rewrite xA yA sub. Qed.
+
+Lemma glinkN (G : hypermap) : subrel (frel node) (@glink G).
+Proof. move => x y. by rewrite /glink /= => ->. Qed.
+
+Lemma sub_node_clink {G : hypermap} : subrel (frel (finv node)) (@clink G).
+Proof. move => x y /eqP <-. by rewrite /clink/= eqxx. Qed.
+
+Lemma in_clink_glink (G : hypermap) (A : pred G) (plainG : plain G) : 
+  fclosed node A -> {in A&, connect (restrict A clink) =2 connect (restrict A glink)}.
+Proof.
+move => clA x y xA yA. apply/idP/idP.
+- case/connectP => [p]. elim: p x xA => [x xA _ -> //|z p IHp x xA /=].
+  rewrite -!andbA => /and4P [_ zA xz pth_p lst_p]. 
+  apply: connect_trans (IHp _ zA pth_p lst_p) => {pth_p lst_p}.
+  case/clinkP : xz xA zA => [->|<-] => xA zA.
+  + apply: connect_mono. apply: sub_restrict. apply: in2W. exact: glinkN.
+    rewrite in_connect_sym // ?connect1 //=. exact: cnodeC.
+  + by apply connect1; rewrite /= xA zA /glink/= eqxx.
+- case/connectP => [p]. elim: p x xA => [x xA _ -> //|z p IHp x xA /=].
+  rewrite -!andbA => /and4P [_ zA xz pth_p lst_p]. 
+  apply: connect_trans (IHp _ zA pth_p lst_p) => {pth_p lst_p IHp}.
+  gen have N,N': x z xA zA {xz} / node x == z -> connect (restrict A clink) x z.
+  { move/eqP => E. rewrite -{}E in zA *. 
+    apply: connect_mono. apply: sub_restrict. apply: in2W. exact: sub_node_clink.
+    rewrite in_connect_sym // ?connect1 //= ?xA ?zA ?finv_f ?eqxx //.
+    * move => u v /eqP <-. by rewrite (clA (finv node u) u) //= f_finv.
+    * by apply/fconnect_sym/finv_inj. }
+  gen have F,F': x z xA zA {xz N N'} / face x == z -> connect (restrict A clink) x z.
+  { move/eqP => E; rewrite -{}E in zA *. by apply: connect1; rewrite /= xA zA clinkF. }
+  case/or3P : xz => //= {N' F'}.
+  rewrite -plain_eq' => // /eqP => E; rewrite -{}E in zA *. 
+  have ? : face x \in A by rewrite (clA (face x) (node (face x))) //=.
+  apply: connect_trans (N (face x) _ _ _ _) => //. exact: F.
+Qed.
+
+Definition avoid_one (G : hypermap) := 
+  forall z x y : G , ~~ cnode z x -> ~~ cnode z y -> connect (restrict [predC cnode z] clink) x y.
+
+Lemma two_connected_avoid (G : hypermap) (plainG : plain G) : 
+  kconnected_map 2 G -> avoid_one G.
+Proof.
+case => _ tcG z x y Hx Hy.
+have:= tcG (pred1 z) _; rewrite card1 => /(_ isT) {tcG} tcG.
+have Nz : cnode z =i fclosure node (pred1 z) by apply/closure1/cnodeC.
+have PNz : [predC cnode z] =i [predC fclosure node (pred1 z)]. 
+{ by move => u; rewrite inE /= Nz. }
+rewrite in_clink_glink //; last exact/predC_closed/connect_closed/cnodeC.
+apply: connect_restrict_mono (tcG x y _ _); rewrite -?PNz //.
+apply/subsetP => u. by rewrite -PNz.
+Qed.
+
+Definition drestrict (G : diGraph) (A : pred G) := DiGraph (restrict A di_edge).
+
+Lemma upathPR (G : diGraph) (x y : G) A :
+  reflect (exists p : seq G, @upath (drestrict A) x y p)
+          (connect (restrict A di_edge) x y).
+Proof. exact: (@upathP (drestrict A)). Qed.
+
+Lemma upath_rconsE (G: diGraph) (x y : G) p : x != y ->
+    upath x y p -> path di_edge x (rcons (behead (belast x p)) y) /\ uniq (rcons (belast x p) y).
+Proof.
+rewrite /upath/pathp; elim/last_ind : p x y => [x y /negbTE-> //|p z ? x y ?]. 
+rewrite !belast_rcons last_rcons /= -andbA => /and4P [H1 H2 H3 /eqP<-].
+by rewrite H1 H2 H3.
+Qed.
+
+Lemma drestrict_upath (G : diGraph) (x y : G) (A : pred G) (p : seq G) :
+  @upath (@drestrict G A) x y p -> @upath G x y p.
+Proof.
+elim: p x => // z p IH x /upath_consE [/= /andP [_ u1] u2 u3]. 
+rewrite upath_cons u1 u2 /=. exact: IH.
+Qed.
+
+(* TODO: 
+   - clean up digraph/sgraph connect/path lemmas
+   - provide link between [p : Path x y] and [path e x (rcons q y)] *)
+Lemma connect_inE (T : finType) (e : rel T) (A : pred T) (x y : T) : 
+  x != y -> connect (restrict A e) x y -> 
+  (exists p, [/\ path e x (rcons p y), uniq (x::rcons p y) & {subset x::rcons p y <= A}]).
+Proof.
+move => xDy. case/(@upathPR (DiGraph e)) => p U. 
+move/upath_rconsE : (drestrict_upath U) => -/(_ xDy) [P1 P2].
+have E : last x p = y by case/andP : U => _; apply: pathp_last.
+rewrite -E -lastI in P2. 
+exists (behead (belast x p)); split => //. 
+- suff -> : rcons (behead (belast x p)) y = p by [].
+  destruct p; rewrite -?E -?lastI //=. by rewrite -E /= eqxx in xDy. 
+- move/upath_rconsE : (U) => /(_ xDy) => -[P _]. 
+  apply/cons_subset; split; last exact: rpath_sub P. 
+  destruct p; simpl in *. by rewrite E eqxx in xDy. 
+  case/upath_consE : U => /=. by rewrite /di_edge/=; case: (x \in A).
+Qed.
+
+Lemma sub_face_clink { G : hypermap } : @subrel G (frel face) clink.
+Proof. by move => u v /eqP ?; apply/clinkP; right. Qed.
+
+Lemma path_take_nth (T : eqType) (e : rel T) x s n : 
+  n < size s -> path e x s -> e (last x (take n s)) (nth x s n).
+Proof.
+elim: s x n => // a s IH x [|n] /=; first by case (e x a).
+rewrite ltnS => ? /andP [_ ?]; by rewrite (set_nth_default a x) ?IH.
+Qed.
+
+Lemma path_take (T : eqType) (e : rel T) x s n : 
+  path e x s -> path e x (take n s).
+Proof. by rewrite -{1}[s](cat_take_drop n) cat_path; case/andP. Qed.
+
+Lemma disjoint_subpath (T : finType) (A B : pred T) (e : rel T) x y (p : seq T) :
+  x \in A -> y \in B -> path e x (rcons p y) -> [disjoint A & B] ->
+  exists u v q, [/\ u \in A, v \in B, path e u (rcons q v), 
+              subseq (u:: rcons q v) (x:: rcons p y) & [disjoint q & [predU A & B]]].
+Proof.
+have [m Hm] := ubnP (size p); elim: m x y p Hm => // n IH x y p p_n xA xB pth_p disAB.
+case: (boolP [disjoint p & [predU A & B]]) => [?|]; first by exists x; exists y; exists p.
+case/pred0Pn => z /andP[z_in_p z_in_AB].
+case/splitP def_p : p _ _ / z_in_p pth_p p_n => [p1 p2].
+rewrite rcons_cat cat_path last_rcons => /andP [pth_p1 pth_p2].
+rewrite size_cat size_rcons addSn ltnS => size_p. 
+have {z_in_AB} [z_in_A|z_in_B] := orP z_in_AB.
+- case:(IH z y p2) => //. apply: leq_ltn_trans size_p. exact: leq_addl. 
+  move => u [v] [q] [uA vB Q1 Q2 Q3]; exists u; exists v; exists q. split => //. 
+  apply: subseq_trans Q2 _. rewrite -(cats1 _ z) -catA cat1s -cat_cons.   
+  exact: suffix_subseq.
+- case:(IH x z p1) => //. apply: leq_ltn_trans size_p. exact: leq_addr. 
+  move => u [v] [q] [uA vB Q1 Q2 Q3]; exists u; exists v; exists q. split => //. 
+  apply: subseq_trans Q2 _. exact: prefix_subseq.
+Qed.
+
+Lemma last_belast (T : eqType) (x : T) (s : seq T) : 
+  uniq (x :: s) -> last x s \in belast x s = false.
+Proof. 
+elim: s x => //= y s IH x /andP [Hx ?]. rewrite inE IH // orbF.
+apply: contraNF Hx => /eqP <-. exact: mem_last.
+Qed.
+
+Lemma last_head_behead (T : eqType) (x : T) (p : seq T) : last (head x p) (behead (rcons p x)) = x.
+Proof. case: p => //= ? ?. exact: last_rcons. Qed.
+
+Lemma last_memE (T : eqType) (x : T) (s : seq T) (a : pred T) : 
+  last x s \in a -> (x \in a) + { y | y \in s & y \in a}.
+Proof. 
+elim/last_ind : s => [|s y _]; first by left.
+by rewrite last_rcons; right;exists y => //; rewrite mem_rcons mem_head.
+Qed.
+
+
+Lemma index_finv (T : finType) (f : T -> T) x : 
+  findex f x (finv f x) = (order f x).-1.
+Proof. by rewrite findex_iter // orderSpred. Qed.
+
+Lemma bar (T : finType) (f : T -> T) x : 
+  injective f -> findex f (f x) x = (order f (f x)).-1.
+Proof. move => inj_f. have := index_finv f (f x). by rewrite finv_f. Qed.
+
+(** Every face of a two connected loopless plain graph is bounded by a
+cycle. In the hypermap representation, this amounts to showing that
+distinct nodes on an f-cycle belong to different n-cycles *)
+(* TODO: simplify further (use [rot_to_arc] for f-cycle) *)
+Lemma two_connected_cyle (G : hypermap) :
+  avoid_one G -> plain G -> loopless G -> planar G ->
+  forall x y : G, x != y -> cface x y -> ~~ cnode x y.
+Proof.
+move => tcG plainG llG planarG x y xDy cf_xy; apply/negP => cn_xy.
+wlog [p [path_p uniq_p disj_p]] : x xDy cf_xy cn_xy / 
+  exists p, [/\ fpath (finv node) y (rcons p x), uniq p & [disjoint p & cface x]].
+{ move => W. 
+  pose o := orbit (finv node) y; pose a := cface x.
+  have [o' def_o] : exists o', o = y :: o' by rewrite /o/orbit -orderSpred /=; eexists.
+  have has_x : has a o'; first (apply/hasP; exists x; last exact: connect0). 
+    suff: x \in o by rewrite def_o inE (negPf xDy).
+    by rewrite -fconnect_orbit same_fconnect_finv // cnodeC.
+  case/split_find def_o' : _ _ _ / has_x => [x' p q a_x' hasNp]; subst o'.
+  have: uniq o by apply: orbit_uniq.
+  have: fcycle (finv node) o by apply/cycle_orbit/finv_inj. 
+  have cf_x'y: cface x' y by apply: connect_trans cf_xy; rewrite cfaceC.
+  rewrite def_o /= rcons_path cat_path -!andbA => /andP [path_p _].
+  rewrite cat_uniq rcons_uniq -!andbA mem_cat mem_rcons inE !negb_or -!andbA eq_sym.
+  move => /andP[? /and5P[_ _ _ uniq_p _]]; apply: (W x') => //. 
+  - rewrite cnodeC -same_fconnect_finv //; apply/connectP; exists (rcons p x') => //.
+    by rewrite last_rcons.
+  - exists p; split => //; rewrite disjoint_has // (eq_has (_ : cface x' =i cface x)) //.
+    move=> z; rewrite !inE; apply: (same_connect cfaceC). 
+    by apply: connect_trans cf_x'y _; rewrite cfaceC. }
+(* Exibiting the f-cycle *)
+have := cycle_orbit faceI x; have := orbit_uniq face x.
+have : y \in orbit face x by rewrite -fconnect_orbit.
+case def_c : (orbit face x) => [//|x0 c].
+move: (def_c).
+have {def_c} -> : x0 = x by move: def_c; rewrite /orbit -orderSpred; case. 
+move => def_c y_in_c uniq_c cycle_c. 
+rewrite inE eq_sym (negbTE xDy) /= in y_in_c.
+(* Splitting the f-cycle *)
+case/splitP def_c' : {1}c _ _ / y_in_c => [c1 c2].
+move: uniq_c. rewrite def_c' /= cat_uniq has_sym has_rcons mem_cat mem_rcons rcons_uniq.
+rewrite !inE (negbTE xDy) !negb_or /= -disjoint_has -!andbA disjoint_sym.
+case/and5P => x_c1 x_c2 y_c1 uniq_c1 /and3P [y_c2 dis_c1_c2 uniq_c2].
+move: path_p; rewrite rcons_path /= => /andP [path_p /eqP lst_p].
+(* Obtain contour connecting [c1] and [c2] *)
+have [u [v] [q] [path_q u_c v_c uniq_q disj_q]]: 
+  exists u v q, [/\ path clink u (rcons q v), u \in c2, v \in c1, uniq q & [disjoint q & [predU cface x & p]]].
+{  have [u [u_c1 Hu]] : exists u, u \in c1 /\ ~~ cnode x u. {
+     destruct c1 as [|a ?]; move: cycle_c cn_xy; rewrite def_c'.
+     - case/andP => /eqP <- _. by rewrite (negbTE (loopless_face _ _ _)). 
+     - rewrite rcons_cons /= rcons_path => /and3P [/eqP<- _ _]. 
+       exists (face x). by rewrite mem_head loopless_face. }
+   have [v [v_c2 Hv]] : exists v, v \in c2 /\ ~~ cnode x v. { 
+     elim/last_ind : c2 def_c' cycle_c cn_xy {x_c2 y_c2 dis_c1_c2 uniq_c2} => [|? a _] /= ->. 
+     - rewrite cats0 /= rcons_path last_rcons => /andP [_ /eqP <-]. 
+       by rewrite cnodeC (negbTE (loopless_face _ _ _)). 
+     - rewrite !(rcons_path,cat_path) /= -!andbA last_cat !last_rcons => /and5P [_ _ _ _ /eqP E ?].
+       exists (finv face x). by rewrite -E finv_f // mem_rcons mem_head cnodeC loopless_face. }
+   have uDv : v != u. 
+   { apply: contraTneq dis_c1_c2 => ?; subst. by apply/pred0Pn; exists u. }
+   have [q [pth_q uniq_q sub_q]] := @connect_inE _ _ _ _ _ uDv (tcG x v u Hv Hu).
+   have [u0 [v0] [q0] [A B C D E]] := disjoint_subpath  v_c2 u_c1 pth_q dis_c1_c2.
+   exists u0; exists v0; exists q0; split => //. 
+   - apply: subseq_uniq uniq_q. apply: subseq_trans D. 
+     exact: subseq_trans (subseq_rcons _ _) (subseq_cons _ _).
+   - move/mem_subseq in D. 
+     apply/disjointP => z in_q0; apply/negP; rewrite !inE negb_or fconnect_orbit def_c.
+     have Nz k : cnode y k -> z != k. 
+     { move => Nyk. have:= connect_trans cn_xy Nyk.
+       apply contraTneq => <-. by apply/sub_q/D; rewrite !(inE,mem_rcons) in_q0. }
+     rewrite def_c' !(inE,mem_rcons,mem_cat) !negb_or !Nz 1?cnodeC //= -negb_or orbC. 
+     move: (disjointFr E in_q0); rewrite inE => -> /=. 
+     apply: contraTN (eqxx z) => z_p; apply/Nz. 
+     rewrite -same_fconnect_finv //. 
+     move/path_connect in path_p. by apply/path_p; rewrite !inE z_p. }
+case/splitP def_c2 : {1}c2 _ _ / (u_c) => [c21 c22]. 
+pose mp := rcons p x ++ rcons c1 y ++ rcons c21 u ++ q.
+suff: Moebius_path mp by apply/negP; exact: planarP.
+move: path_q; rewrite rcons_path => /andP [path_q lst_q].
+have/andP [dis_q_f dis_q_p] : [disjoint q & (x::c)] && [disjoint p & q].
+{ move: disj_q. rewrite disjoint_sym disjointU => /andP [A ->]; rewrite andbT disjoint_sym.
+  by apply: disjointWl A; apply/subsetP => ?; rewrite -def_c -fconnect_orbit. }
+rewrite /mp headI /Moebius_path -{2}headI /=.
+apply/and3P; split.
+- suff: uniq (rcons p x ++ c ++ q). 
+  { apply: subseq_uniq. apply: cat_subseq => //. rewrite catA. apply: cat_subseq => //.
+    rewrite def_c' def_c2. apply: cat_subseq => //. exact: prefix_subseq. }
+  rewrite -cats1 -catA [[:: x] ++ _ ++ _]catA cat1s -def_c.
+  rewrite cat_uniq has_cat negb_or -!disjoint_has uniq_p /=.
+  rewrite ![[disjoint _ & p]]disjoint_sym dis_q_p (disjointWr _ disj_p). 
+  2: by apply/subsetP => z; rewrite -fconnect_orbit.
+  rewrite cat_uniq orbit_uniq -disjoint_has disjoint_sym uniq_q /= andbT.
+  by rewrite disjoint_sym def_c.
+- rewrite !catA cat_path !last_cat last_rcons path_q andbT -catA.
+  rewrite cat_path last_head_behead (_ : path _ _ _) /=.
+  + move/(sub_path sub_face_clink) : cycle_c. 
+    by rewrite def_c' def_c2 !rcons_cat catA [in X in X -> _]cat_path => /andP [-> _].
+  + move/(sub_path sub_node_clink): path_p lst_p. destruct p as [|z p] => //= /andP [A B] <-.
+    by rewrite rcons_path B -{1}[last z p](f_finv nodeI) clinkN.
+- rewrite 3!last_cat last_rcons. 
+  have -> : node (head x p) = y. 
+  { move: path_p lst_p. destruct p as [|z p]=> /= [_ <-|/andP[/eqP <- _] _]; exact: f_finv. }
+  suff -> : finv node (last u q) = v. 
+  { by rewrite !mem2_cat (_ : mem2 (rcons c1 y) v y) // -cats1 mem2_cat v_c !inE eqxx. }
+  case/clinkP: lst_q => [->|def_v]; first by rewrite ?finv_f. 
+  case: notF. (* the last step of [u::rcons q v] cannot be an f-step *)
+  have: finv face v \in x::c1. 
+  { have : fpath face x c1. 
+    { move: cycle_c. rewrite def_c' -cat1s catA /= rcons_cat cat_path rcons_path. by case: (fpath _ _ c1). }
+    case/splitP : v_c => [p1 p2 _]. rewrite cat_path !rcons_path last_rcons -andbA /=.
+    case/and3P => _ /eqP <- _. by rewrite finv_f // -cats1 -catA /= -cat_cons mem_cat  mem_last. }
+  rewrite -{}def_v finv_f //. case/last_memE => [|[z Z1]].
+  + rewrite inE (disjointFr dis_c1_c2) // orbF => E. by rewrite -(eqP E) u_c in x_c2.
+  + rewrite inE; case/predU1P => [?|H].
+    * subst z. by rewrite (disjointFl dis_q_f) // mem_head in Z1.
+    * by rewrite (disjointFl dis_q_f) // def_c' !(inE,mem_rcons,mem_cat) H in Z1. 
+Qed.
+
+Print Assumptions two_connected_cyle.

--- a/theories/hcycle.v
+++ b/theories/hcycle.v
@@ -88,15 +88,15 @@ apply: connect_restrict_mono (tcG x y _ _); rewrite -?PNz //.
 apply/subsetP => u. by rewrite -PNz.
 Qed.
 
-Definition drestrict (G : diGraph) (A : pred G) := DiGraph (restrict A di_edge).
+Definition drestrict (G : diGraph) (A : pred G) := DiGraph (restrict A (--)).
 
 Lemma upathPR (G : diGraph) (x y : G) A :
   reflect (exists p : seq G, @upath (drestrict A) x y p)
-          (connect (restrict A di_edge) x y).
+          (connect (restrict A (--)) x y).
 Proof. exact: (@upathP (drestrict A)). Qed.
 
 Lemma upath_rconsE (G: diGraph) (x y : G) p : x != y ->
-    upath x y p -> path di_edge x (rcons (behead (belast x p)) y) /\ uniq (rcons (belast x p) y).
+    upath x y p -> path (--) x (rcons (behead (belast x p)) y) /\ uniq (rcons (belast x p) y).
 Proof.
 rewrite /upath/pathp; elim/last_ind : p x y => [x y /negbTE-> //|p z ? x y ?]. 
 rewrite !belast_rcons last_rcons /= -andbA => /and4P [H1 H2 H3 /eqP<-].
@@ -127,7 +127,7 @@ exists (behead (belast x p)); split => //.
 - move/upath_rconsE : (U) => /(_ xDy) => -[P _]. 
   apply/cons_subset; split; last exact: rpath_sub P. 
   destruct p; simpl in *. by rewrite E eqxx in xDy. 
-  case/upath_consE : U => /=. by rewrite /di_edge/=; case: (x \in A).
+  case/upath_consE : U => /=. by rewrite /edge_rel/=; case: (x \in A).
 Qed.
 
 Lemma sub_face_clink { G : hypermap } : @subrel G (frel face) clink.

--- a/theories/hmap_ops.v
+++ b/theories/hmap_ops.v
@@ -1,0 +1,1852 @@
+From mathcomp Require Import all_ssreflect.
+Require Import edone preliminaries bij.
+From fourcolor Require Import hypermap geometry cfmap jordan color coloring combinatorial4ct.
+From fourcolor Require Import walkup.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+(** * Constructions on Hypermaps *)
+
+(** ** Preliminaries *)
+
+(** These lemmas depend only on definitions within the fourcolor
+development. Among other thins, we provide dedicated lemmas for the
+derived Walkup operations, to simplify their application *)
+
+Lemma genus_walkupN_eq (G : hypermap) (z : G) : 
+  ~~ cnode z (face z) -> genus (WalkupN z) = genus G.
+Proof. 
+move => ncross. 
+rewrite /WalkupN genus_permF genus_WalkupE_eq ?genus_permN //.
+by right.
+Qed.
+
+Lemma genus_walkupF_eq (G : hypermap) (z : G) : 
+  ~~ cface z (edge z) -> genus (WalkupF z) = genus G.
+Proof. 
+move => ncross. 
+rewrite /WalkupN genus_permN genus_WalkupE_eq ?genus_permF //.
+by right.
+Qed.
+
+Lemma le_genus_WalkupF (G : hypermap) (x : G) : genus (WalkupF x) <= genus G.
+Proof. by rewrite genus_permN -[X in _ <= X]genus_permF le_genus_WalkupE. Qed.
+
+Lemma loopless_face (G : hypermap) (x : G) : plain G -> loopless G -> ~~ cnode x (face x).
+Proof. move => plFG /existsPn llG. by rewrite cnode1r plain_eq'. Qed.
+
+Lemma genus_gt0 (D : hypermap) : 
+  (0 < genus D) = (0 < Euler_lhs D - Euler_rhs D).
+Proof. by rewrite even_genusP -addnBA // subnn addn0 double_gt0. Qed.
+
+Lemma EqHypermapEN (G : hypermap) (e n f : G -> G) (Eenf : cancel3 e n f) :
+  edge =1 e -> node =1 n -> G =m Hypermap Eenf.
+Proof.
+move => eE nE; suff fE : face =1 f by apply: EqHypermap.
+by move => x; rewrite -{1}[x](@faceK (Hypermap Eenf)) /= -eE -nE nodeK.
+Qed.
+
+#[export] Hint Resolve faceI nodeI edgeI : core.
+
+Lemma gcompF (G : hypermap) : subrel (cface : rel G) gcomp. 
+Proof. by apply: connect_sub => u v /= A; apply: connect1; rewrite /glink/= A. Qed.
+
+Lemma gcompN (G : hypermap) : subrel (cnode : rel G) gcomp. 
+Proof. by apply: connect_sub => u v /= A; apply: connect1; rewrite /glink/= A. Qed.
+
+
+Lemma loopless_arity (G : hypermap) : 
+  plain G -> loopless G -> forall x : G, 1 < arity x.
+Proof. 
+move=> plainG llG; apply/forallP; apply: contraNT llG.
+case/forallPn => x; rewrite -leqNgt => ar_le_1.
+have ar1 : arity x = 1 by apply/eqP; rewrite eqn_leq ar_le_1 order_gt0.
+have := iter_face_arity x; rewrite ar1 /= => fx.
+existsb x. by rewrite -plain_eq' // fx -cnode1r.
+Qed.
+
+
+(** ** Adjacency *)
+
+(**We define adjaceny of nodes. In the four-color theorem [adj] is used to denote adjacency of face, hence we use [adjn] here. *)
+
+Definition adjn {D : hypermap} (x y : D) := [exists z in cnode x, edge z \in cnode y].
+
+Lemma adjnI (G : hypermap) (z x y : G) : 
+  cnode x z -> cnode y (edge z) -> adjn x y.
+Proof. by move => ? ?; apply/exists_inP; exists z. Qed.
+Arguments adjnI G z [x y].
+
+Lemma adjn_node1 (G : hypermap) (x y : G) : adjn x y = adjn (node x) y.
+Proof. by apply: eq_existsb => z; rewrite !inE -cnode1. Qed.
+
+Lemma adjn_node1r (G : hypermap) (x y : G) : adjn x y = adjn x (node y).
+Proof. by apply: eq_existsb => z; rewrite !inE -cnode1. Qed.
+
+Lemma adjn_edge (G : hypermap) (x : G) : adjn x (edge x).
+Proof. exact: (adjnI G x). Qed.
+
+Lemma adjnC (G : hypermap) (x y : G) : 
+  plain G -> adjn x y = adjn y x.
+Proof.
+move=> plain_G.
+wlog suff S : x y / adjn x y -> adjn y x; first by apply/idP/idP; exact: S.
+case/exists_inP => z; rewrite !inE => x_z z_ez. 
+by apply/exists_inP; exists (edge z); rewrite // plain_eq.
+Qed.
+
+Lemma adjn_loopless (D : hypermap) (x y : D) : 
+  loopless D -> cnode x y -> adjn x y = false.
+Proof.
+move => llD n_xy. apply: contraNF llD => /exists_inP[z]; rewrite !inE => n_xz n_y_ez.
+existsb z. apply: connect_trans n_y_ez. apply: connect_trans n_xy. by rewrite cnodeC.
+Qed.
+
+
+(** ** Isomorphims of Hypermaps *)
+
+Arguments bij_injective [A B] f [_ _] _.
+Arguments bij_injective' [A B] f [_ _] _.
+
+Section HIso.
+Variable (G H : hypermap).
+
+Record hiso := Hiso { 
+  hiso_dart :> bij G H;
+  hiso_edge x : hiso_dart (edge x) = edge (hiso_dart x);
+  hiso_node x : hiso_dart (node x) = node (hiso_dart x) }.
+
+Lemma hiso_face (i : hiso) x : i (face x) = face (i x).
+Proof. by rewrite -{2}[x]faceK hiso_edge hiso_node nodeK. Qed.
+
+(** Commutation of the third permutation is a consequence. We could
+provide "smart" constructors in case one of [hiso_edge] or [hiso_node]
+is harder to establish than [hiso_face]. So far, this is not needed. *)
+
+Hypothesis (i : hiso).
+
+Lemma comm_adj (e' : rel H) (e : rel G) (a : pred H) :
+  (forall x y, e' (i x) (i y) = e x y) -> rel_adjunction i e' e a.
+Proof.
+move => com. constructor; first by move => x _; exists (i^-1 x); rewrite bijK'.
+move => x' y' _. apply/idP/idP; case/connectP. 
+- move => p pth_p ->. elim: p x' pth_p => //= z' p IHp x' /andP [E pth_p].
+  rewrite -com in E. exact: connect_trans (connect1 E) (IHp _ pth_p).
+- move => p pth_p I. rewrite -[y'](bijK i) {}I.
+  elim: p x' pth_p => //= [x' _|z' p IHp x' /andP [E pth_p]]; first by rewrite bijK.
+  rewrite -[z'](bijK' i) com in E.
+  apply: connect_trans (connect1 E) _. rewrite -[z'](bijK' i) in pth_p.
+  move/IHp in pth_p. by rewrite bijK' in pth_p.
+Qed.
+
+Lemma hiso_fcard (f : G -> G) (f' : H -> H) : 
+  injective f ->
+  (forall x, i (f x) = f' (i x)) -> fcard f G = fcard f' H.
+Proof.
+move => inj_f com_f_f'.
+have inj_f' : injective f'.
+{ move => x y. rewrite -{1}[x](bijK' i) -{1}[y](bijK' i) -!com_f_f'.
+  by move/(bij_injective i)/inj_f/(bij_injective' i). }
+suff adj : fun_adjunction i f' f H. 
+{ rewrite (adjunction_n_comp _ _ _ _ adj) //; exact: fconnect_sym. }
+apply: comm_adj => //= x y. by rewrite -com_f_f' inj_eq.
+Qed.
+
+Lemma hiso_fconnect (f : G -> G) (f' : H -> H) : 
+  (forall x, i (f x) = f' (i x)) -> 
+  forall x y, fconnect f x y = fconnect f' (i x) (i y).
+Proof. 
+move => com x y. apply: rel_functor. apply: (comm_adj H). 2: done.
+by move => {x y} x y; rewrite /= -com inj_eq.
+Qed.
+
+Definition hiso_cedge := hiso_fconnect (hiso_edge i).
+Definition hiso_cnode := hiso_fconnect (hiso_node i).
+Definition hiso_cface := hiso_fconnect (hiso_face i).
+
+Lemma hiso_genus : genus G = genus H.
+Proof.
+have fcardF := hiso_fcard faceI (hiso_face i).
+have fcardN := hiso_fcard nodeI (hiso_node i).
+have fcardE := hiso_fcard edgeI (hiso_edge i).
+rewrite /genus /Euler_rhs fcardF fcardN fcardE; do 2 f_equal.
+rewrite /Euler_lhs. rewrite (card_bij i). 
+suff adj : rel_adjunction i glink glink H. 
+{ rewrite (adjunction_n_comp _ _ _ _ adj) //; exact: glinkC. }
+apply: comm_adj => x y.
+by rewrite /glink/= -hiso_edge -hiso_face -hiso_node !(inj_eq).
+Qed.
+
+Lemma hiso_plain : plain G = plain H.
+Proof.
+congr (is_true _); apply/plainP/plainP.
+- move => plainG x _; have [G1 G2] := plainG (i^-1 x) isT.
+  by rewrite -[x](bijK' i) -!hiso_edge G1 inj_eq.
+- move => plainH x _; have [H1 H2] := plainH (i x) isT.
+  rewrite -!hiso_edge inj_eq // in H1 H2.
+  by rewrite H2 (bij_injective i H1).
+Qed.
+
+Lemma hiso_adjn x y : adjn (i x) (i y) = adjn x y.
+Proof. 
+apply/exists_inP/exists_inP => -[z Z1 Z2].
+- exists (i^-1 z); first by rewrite inE hiso_cnode bijK'.
+  by rewrite inE hiso_cnode hiso_edge bijK'.
+- exists (i z); first by rewrite inE -hiso_cnode.
+  by rewrite inE -hiso_edge -hiso_cnode.
+Qed.
+
+End HIso.
+
+Tactic Notation "hiso" uconstr(f) :=
+  match goal with |- hiso ?F ?G => apply (@Hiso F G f) end.
+
+Lemma hiso_glink (G G' : hypermap) (h : hiso G G') x y : 
+  glink x y = glink (h x) (h y).
+Proof. 
+by rewrite /glink/= -hiso_edge -hiso_node -hiso_face !inj_eq.
+Qed.
+
+(** Special case where the shape of both graphs is known and the
+isomorphim is the identity. Used for symmetry reasoning with [merge] *)
+Lemma hiso_id_glink (D : finType) e n f eK e' n' f' eK' :
+  let G := @Hypermap D e n f eK in
+  let G' := @Hypermap D e' n' f' eK' in 
+  forall (i : hiso G' G), i =1 id -> @glink G' =2 @glink G.
+Proof. 
+move => G G' i iE x z. by rewrite (hiso_glink i) !iE.
+Qed.
+Arguments hiso_id_glink [D] [e n f]%function_scope [eK] [e' n' f']%function_scope [eK'].
+
+(** * Operations on Hypermaps *)
+
+(** ** The Switch Construct *)
+
+(** The switch function switches the successors of two elements of a
+permutation. (The definition doesn't require injectivity, but we
+mainly use it on the permutations making up hypermap). This is a
+fairly basic operation and can be used to implement the spliting and
+merging of nodes (node cycles) in a way that preserves planarity *)
+
+Section switch.
+Variable (G : finType).
+
+Definition switch x y (f : G -> G) := [fun z => 
+  if z == x then f y else
+  if z == y then f x else f z].
+
+Lemma switchxx x f : switch x x f =1 f.
+Proof. move => z /=. by case (altP (z =P x)) => [->|]. Qed.
+
+Lemma switchC x y f : switch x y f =1 switch y x f.
+Proof. 
+case: (altP (x =P y)) => [<-|xDy]; rewrite ?switchxx //= ?eqxx.
+move => z /=. do ! (case (z =P _) => [->|] //); by rewrite (negbTE xDy). 
+Qed.
+
+Lemma fswitchC x y f : fconnect (switch x y f) =2 fconnect (switch y x f).
+Proof. apply: eq_fconnect. exact: switchC. Qed.
+
+Variables (x y : G).
+
+Lemma switchK f : switch x y (switch x y f) =1 f.
+Proof. 
+move => z. case: (altP (x =P y)) => [<-|xDy]; rewrite ?switchxx //= ?eqxx.
+case: (altP (z =P x)) => [->|zDx].
+- by rewrite [_ == x]eq_sym (negbTE xDy).
+- by case: (altP (z =P y)) => // ->.
+Qed.
+
+Lemma switchE f : {in [predC (pred2 x y)], switch x y f =1 f}.
+Proof. move => z. rewrite !inE /switch/=. by do 2 (case (_ == _)). Qed.
+
+Lemma switch_base f : fun_base id f (switch x y f) (pred2 x y).  
+Proof. move=> u v ?. by rewrite [switch]lock /= -lock switchE. Qed.
+
+
+Hypothesis (f : G -> G) (inj_f : injective f).
+Local Notation xswitch := (switch x y f).
+
+Lemma can_switch : cancel xswitch (switch (f y) (f x) (finv f)).
+Proof. 
+move => z; case: (altP (x =P y)) => [->|xDy]; rewrite ?switchxx ?finv_f //=.
+case: (altP (z =P x)) => [->|zDx]; first by rewrite eqxx finv_f.
+case: (altP (z =P y)) => [->|zDy]; first by rewrite (inj_eq inj_f) (negbTE xDy) eqxx finv_f.
+by rewrite !(inj_eq inj_f) ?(negbTE zDy) ?(negbTE zDx) ?eqxx finv_f.
+Qed.
+
+Lemma switch_inj : injective xswitch.
+Proof. exact: can_inj can_switch. Qed.  
+
+Lemma fconnect_f_switch z : 
+  ~~ fconnect f x z -> fconnect f z y -> fconnect xswitch z y.
+Proof.
+move => N /connectP [p]; elim: p z N => //= [_ _ _ -> //|u p IH z N /andP[/eqP E P L]].
+have zDx : z != x by apply: contraNneq N => ->.
+case: (altP (z =P y)) => [-> //|zDy].
+apply: connect_trans (connect1 _) (IH _ _ P L) => /=.
+- by rewrite (negbTE zDx) (negbTE zDy) E.
+- by rewrite -E -same_fconnect1_r.
+Qed.
+
+Lemma iter_switchE z m : 
+  (forall n, n < m -> iter n f z \in [predC pred2 x y]) -> 
+  forall k, k <= m -> iter k xswitch z = iter k f z.
+Proof.
+move => H k lt_m. 
+have {H lt_m m} : forall n : nat, n < k -> iter n f z \in [predC pred2 x y]. 
+{ by  move => n Hn; apply: H; apply: leq_trans lt_m. }
+elim: k z => // k IH z Hk; rewrite !iterSr switchE ?IH // ; last exact: (Hk 0).
+move => n Hn; by rewrite -iterSr Hk // ltnS.
+Qed.
+
+
+Lemma fconnect_switched (xDy : x != y) : fconnect xswitch x y  = ~~ fconnect f x y.
+Proof.
+have ? := switch_inj.
+apply/idP/idP.
+- apply: contraTN => fc_xy; rewrite same_fconnect1 //= eqxx. 
+  have [? ?] : fconnect f (f y) y /\ fconnect f (f y) x. 
+  { by rewrite -!same_fconnect1 ?connect0 1?fconnect_sym. }
+  pose m := findex f (f y) x; pose n := findex f (f y) y.
+  have m_lt_n : m < n. 
+  { rewrite /m /n ltn_neqAle; apply/andP; split.
+    - apply: contra_neq (xDy). by apply: index_inj; rewrite -fconnect_orbit.
+    - by rewrite -{3}[y](finv_f inj_f) findex_finv -ltnS orderSpred findex_max. }
+  have switch_f k : k <= m -> iter k xswitch (f y) = iter k f (f y).
+  { apply: iter_switchE => j j_lt_k. rewrite !inE negb_or. 
+    rewrite !before_findex -?same_fconnect1 -1?fconnect_sym //.
+    exact: ltn_trans j_lt_k _. }
+  have: looping xswitch (f y) m.+1.
+  { by rewrite /looping trajectS iterS switch_f // iter_findex /= ?eqxx ?mem_head. }
+  apply: iter_looping => k k_lt_m. rewrite switch_f //. apply: before_findex => //.
+  exact: leq_trans m_lt_n.
+- move => N. rewrite same_fconnect1 //= eqxx. apply: fconnect_f_switch.
+  + by rewrite -same_fconnect1_r.
+  + by rewrite -same_fconnect1.
+Qed.
+
+Lemma fconnect_switchV z :  
+  fconnect f z x -> fconnect xswitch z x || fconnect xswitch z y.
+Proof. 
+move => fc_zx; case: (boolP (fconnect (switch x y f) z x)) => //=. 
+case/connectP : (fc_zx) => p; elim: p z fc_zx => /= [? _ _ <- //|]; first by rewrite connect0.
+have ? := switch_inj; move => a p IHp z fc_zx /andP [/eqP<- P1 P2] sw_zx. 
+wlog zDxy : / z \in [predC pred2 x y].
+{ move => W; case: (altP (z =P y)) => [-> //|zDx]; apply: W; rewrite !inE (negbTE zDx) orbF.
+  by apply: contraNneq sw_zx => ->. }
+rewrite same_fconnect1 ?switchE // in sw_zx.
+by rewrite same_fconnect1 ?switchE ?IHp // -?same_fconnect1.
+Qed.
+
+End switch.
+Arguments switchK {G x y f}.
+Arguments switchC {G x y f}.
+Arguments eq_fclosure {T f f' a}.
+
+Lemma closure_switched (G : finType) (x y : G) (f : G -> G) (inj_f : injective f) :
+  fclosure f (pred2 x y) =i fclosure (switch x y f) (pred2 x y).
+Proof.
+wlog suff: f inj_f / {subset fclosure f (pred2 x y) <= fclosure (switch x y f) (pred2 x y)}.
+{ move => W z; apply/idP/idP; first exact: W.
+  move/W; rewrite (eq_fclosure switchK); apply; exact: switch_inj. }
+move => z /closureP -[u] /pred2P [->|->] f_z; apply/closureP. 
+- by have [A|A] := orP (fconnect_switchV y inj_f f_z); [exists x| exists y] => //; rewrite inE eqxx.
+- have := (fconnect_switchV x inj_f f_z); rewrite ![fconnect (switch y x f) _ _](eq_fconnect switchC).
+  by case/orP; [exists y| exists x] => //; rewrite inE eqxx.
+Qed.
+
+Section switch.
+Hypothesis (G : finType) (f : G -> G) (inj_f : injective f).
+
+Lemma fcard_switch x y (xDy : x != y) :
+  fcard (switch x y f) G = if fconnect f x y then (fcard f G).+1 else (fcard f G).-1.
+Proof.
+pose xswitch := switch x y f.
+have f_sym := fconnect_sym inj_f; have sw_sym := fconnect_sym (@switch_inj _ x y _ inj_f).
+pose a := fclosure f (pred2 x y).
+have cCa : fclosed f [predC a] by apply/predC_closed/closure_closed.
+have eq_ab : a =i fclosure xswitch (pred2 x y) by apply: closure_switched.
+rewrite (n_compC a) (eq_n_comp_r eq_ab) (n_comp_closure2 sw_sym).
+rewrite (n_compC a) (n_comp_closure2 f_sym). 
+have adj_f: fun_adjunction id f xswitch (predC a).
+{ apply: strict_adjunction => //.
+  - by apply/subsetP => z _; rewrite -[z]/(id z) codom_f.
+  - move => u v H. apply: switch_base. apply: contraNN H. 
+    rewrite [in X in _ -> X]/= negbK; exact: mem_closure. }
+rewrite fconnect_switched // negbK (adjunction_n_comp _ f_sym sw_sym _ adj_f) //.
+rewrite !(eq_n_comp_r (_ : _ =i [predC a])) //.
+by case: (fconnect f x y); rewrite /= ?add2n ?add1n.
+Qed.
+
+(** More lemmas on [switch], mainly for the case where [~~ fconnect f
+x y], mainly used when reasoning about adjacency in [merge G x y]. *)
+
+Lemma fconnect_switch_x_fx x y : 
+  ~~ fconnect f x y -> fconnect (switch x y f) x (f x).
+Proof.
+move=> n_xy; have xDy : x != y by apply: contraNneq n_xy => ->.
+apply: (connect_trans (y := y)); first by rewrite fconnect_switched.
+by apply: connect1; rewrite /= ?eqxx [_ == x]eq_sym (negbTE xDy).
+Qed.
+
+Lemma switch_subrel x y : 
+  ~~ fconnect f x y -> subrel (fconnect f) (fconnect (switch x y f)).
+Proof.
+move => n_xy u v. 
+case/connectP => p; elim: p u => [|z p IHp] u /=; first by move => _ ->.
+move => /andP[/eqP fu pth_p] lst_p. 
+apply: (connect_trans (y := z)); last exact: IHp.
+rewrite -fu => {IHp z pth_p lst_p fu}. 
+have [u_xy|uNxy] := boolP (u \in pred2 x y); last first.
+  by apply: connect1; rewrite [switch]lock /= -lock switchE.
+case/pred2P : u_xy => ->; first exact: fconnect_switch_x_fx.
+by rewrite fswitchC; apply: fconnect_switch_x_fx; rewrite fconnect_sym.
+Qed.
+
+Variables (x y : G).
+
+Lemma switch_disconnected_lr u v : 
+  ~~ fconnect f x y -> fconnect f x u -> fconnect f y v -> fconnect (switch x y f) u v.
+Proof.
+case: (eqVneq x y) => [->|xDy]; first by rewrite connect0.
+move => xy. move: (xy); rewrite -fconnect_switched // => sxy xu yv.
+apply: connect_trans _ (switch_subrel xy yv).
+apply: connect_trans sxy. apply: (switch_subrel xy).
+by rewrite fconnect_sym.
+Qed.
+
+Lemma fconnect_switchE_aux u v : ~~ fconnect f x y -> 
+  fconnect (switch x y f) u v -> 
+  [|| fconnect f u v, fconnect f u x && fconnect f v y | fconnect f u y && fconnect f v x].
+Proof.
+move => n_xy. case: (boolP (fconnect f u v)) => //= fNuv sw_uv.
+have [Cu Cv] : u \in fclosure f (pred2 x y) /\ v \in fclosure f (pred2 x y).
+{ have sw_inj := @switch_inj _ x y _ inj_f.
+  have ? := fconnect_sym sw_inj.
+  wlog suff S : u v fNuv sw_uv / u \in fclosure f (pred2 x y).
+    by split; [exact: (S u v)|apply: (S v u)]; rewrite fconnect_sym.
+  rewrite closure_switched // closure_pred2 // inE /= -!closure1 //.
+  apply: contraNT fNuv; rewrite negb_or !inE ![_ _ _ u]fconnect_sym //. 
+  move/andP => [A B]. apply : sub_in_connect sw_uv => z Hz z' /=.
+  rewrite /switch/= [z == x]rwF 1?[z == y]rwF //; by apply: contraTneq Hz => ->. }
+case/closureP : Cu => /= ? /pred2P [-> f_ux|-> f_uy]. 
+  case/closureP : Cv => /= ? /pred2P [-> f_vx|-> ->]; last by rewrite f_ux.
+  apply: contraNT fNuv => _. apply: connect_trans f_ux _. by rewrite fconnect_sym.
+case/closureP : Cv => /= ? /pred2P [-> ->|-> f_vy]; first by rewrite f_uy.
+apply: contraNT fNuv => _. apply: connect_trans f_uy _. by rewrite fconnect_sym.
+Qed.
+
+Lemma fconnect_switchE u v : ~~ fconnect f x y -> 
+  fconnect (switch x y f) u v =
+  [|| fconnect f u v, fconnect f u x && fconnect f v y | fconnect f u y && fconnect f v x].
+Proof.
+move => n_xy. apply/idP/idP; first exact: fconnect_switchE_aux.
+case/or3P; first exact: switch_subrel.
+  by case/andP => ? ?; apply: switch_disconnected_lr => //; by rewrite fconnect_sym.
+case/andP => ? ?. rewrite fconnect_sym; last exact: switch_inj.
+apply: switch_disconnected_lr => //; by rewrite fconnect_sym.
+Qed.
+
+End switch.
+
+(** ** The merge operation *)
+
+(** When called on two darts [x] and [y] from distinct node cycles,
+[merge G x y] merges the node cycles of [x] and [x] at [x] and [y] by
+swapping their node successors, and adapting the face permutation
+accordingly. This operation is clearly self-inverting, but for now we
+only use it to merge nodes, and not to split nodes. *)
+
+Section merge.
+Variable (G : hypermap).
+
+Lemma merge_cancel3 (x y : G) :
+  cancel3 edge (switch x y node) (switch (finv face y) (finv face x) face).
+Proof. 
+move => z /=. rewrite !f_finv //. 
+case: (altP (edge z =P finv face y)) => [|A].
+  rewrite eqxx -{2}[y](f_finv faceI) => <-. exact: edgeK.
+case: (altP (edge z =P finv face x)) => [e_z|B].
+  by case: (altP (y =P x)) => [->|?]; rewrite ?eqxx -[z]edgeK e_z f_finv.
+rewrite !ifF ?edgeK //. 
+- apply: contra_neqF A => /eqP <-. by rewrite finv_f.
+- apply: contra_neqF B => /eqP <-. by rewrite finv_f.
+Qed. 
+
+Definition merge (x y : G) := Hypermap (merge_cancel3 x y).
+
+End merge.
+
+Definition merge_inv (G : hypermap) (x y : G) : hiso (@merge (@merge G x y) x y) G.
+Proof. hiso bij_id => //. exact: switchK. Defined.
+
+Lemma merge_inv_eqm (G : hypermap) (x y : G) : @merge (@merge G x y) x y =m G.
+Proof.
+case: G x y => D e n f /= eK x y; apply: EqHypermapEN => //=. 
+exact: switchK. 
+Qed.
+
+Definition mergeC (G : hypermap) (x y : G) : hiso (merge x y) (merge y x).
+Proof. hiso bij_id => //. exact: switchC. Defined.
+
+Lemma mergeC_eqm (G : hypermap) (x y : G) : merge x y =m merge y x.
+Proof. apply: EqHypermapEN => //=. exact: switchC. Qed.
+
+Arguments clinkF {G x}.
+
+Arguments switch : simpl never.
+
+(** The rest of this subsection is devoted to showing that [merge G x y]
+ preserves the genus of [G] whenever we have either [~~ gcomp x y]
+or [(cnode x y (+) cface x y)]. Here we went to route to pove this
+direcly showing that the Euler formula is preserved. As an
+alternative, it would be possible to express the "merge" direction as
+an inverse-WalupF (splitting the face-cycle) followed by a WalkupN
+operation (merging the node cycles). However, this would require
+making the intermediate hypermap explicit and would not be a nice as
+for other operations, that can be expressed as (inverse) double Walkup
+operations. *)
+
+(** This proof is unintelligible without [Set Printing Implicit.] *)
+Set Printing Implicit.
+
+Lemma closure_merged (G : hypermap) (x y : G) (xDy : x != y) :
+  closure (@glink (merge x y)) (pred2 x y) =i closure glink (pred2 x y).
+Proof.
+wlog suff S : G x y xDy / 
+  closure (@glink (merge x y)) (pred2 x y) \subset closure glink (pred2 x y).
+{ apply/subset_eqP/andP; split; first exact: S. 
+  suff E: @glink (@merge (merge x y) x y) =2 @glink G. 
+    rewrite -(eq_subset (eq_closure _ (eq_connect E))). exact: S.
+  case: G x y {xDy} => D e n f eK x y. 
+  pose i := merge_inv x y. by apply: (hiso_id_glink i). }
+apply/subsetP => z /closureP [x0]; rewrite !inE => x_or_y.
+wlog -> : G x y xDy z x0 {x_or_y} / x0 = x.
+{ move => W. case/pred2P : x_or_y => [|A B]; first exact: W. 
+  have {B} B : (gcomp : rel (merge y x)) z x0 by rewrite -(eq_connect (hiso_id_glink (mergeC x y) _)).
+  have {W} W := W G y x _ z x0 A B. 
+  rewrite (eq_closure_r (_ : pred2 x y =i pred2 y x)) ?W 1?eq_sym //.
+  by move => u ; rewrite !inE orbC. }
+rewrite -clink_glink ; case/connectP => p. 
+elim: p z => /=  [z _ -> |z p IH z' /andP [l_z'_z pth_p] lst_p]; first by apply: mem_closure; rewrite !inE eqxx.
+have {IH pth_p lst_p} IHp := IH _ pth_p lst_p.
+rewrite -(eq_closure _ (@clink_glink _)); rewrite -(eq_closure _ (@clink_glink _)) in IHp.
+have [? ?] : x \in pred2 x y /\ y \in pred2 x y by rewrite !inE !eqxx.
+case/clinkP : l_z'_z => [E|]. 
+- rewrite {}E /=. case: (altP (z =P x)) => [Ez|zDx]; last case: (altP (z =P y)) => [Ez |zDy]. 
+  + apply/closureP; exists y => //. by rewrite connect1 // clinkN.
+  + apply/closureP; exists x => //. by rewrite connect1 // clinkN.
+  + apply: closure_connect IHp. by rewrite connect1 // clinkN.
+- have F (u:G) : connect clink (finv face u) u. 
+  { apply: connect_trans (connect1 clinkF) _. by rewrite (f_finv faceI). }
+  case: (altP (z' =P finv face y)) => [-> _|N1]; first by apply/closureP; exists y.
+  case: (altP (z' =P finv face x)) => [-> _|N2 E]; first by apply/closureP; exists x.
+  rewrite /= (negbTE N1) (negbTE N2) in E; rewrite -[z'](finv_f faceI) E. 
+  apply: closure_connect IHp. apply: connect_trans (connect1 clinkF) _. 
+  by rewrite (f_finv faceI).
+Qed.
+
+Unset Printing Implicit.
+
+Lemma n_comp_merge_rest (G : hypermap) (x y : G) (xDy : x != y) : 
+  n_comp glink [predC closure glink (pred2 x y)] = 
+  n_comp (glink : rel (merge x y)) [predC closure (@glink (merge x y)) (pred2 x y)].
+Proof.
+set a := closure glink (pred2 x y).
+set b := closure (@glink (merge x y)) (pred2 x y).
+have eq_b_a : b =i a by apply closure_merged.
+have C_ab : [predC b] =i [predC a] by move=>z;rewrite [in RHS]inE/= -eq_b_a.
+have [? ?] : x \in pred2 x y /\ y \in pred2 x y by rewrite !inE !eqxx.
+rewrite (eq_n_comp_r C_ab); apply: (@in_eq_n_comp).
+- move => u v /=. exact: glinkC. 
+- move => u v /=. exact: (@glinkC (merge x y)). 
+- apply/predC_closed/closure_closed. exact: glinkC.
+- apply/predC_closed; rewrite -(eq_closed_r eq_b_a).
+  apply: closure_closed. exact: (@glinkC (merge x y)). 
+- move => u v Hu _. rewrite !inE/= in Hu; rewrite /glink /= !ifF //.
+  + apply: contraNF Hu => /eqP->. apply/closureP; exists x => //. 
+    apply gcompF. by rewrite cface1 f_finv.
+  + apply: contraNF Hu => /eqP->. apply/closureP; exists y => //. 
+    apply gcompF. by rewrite cface1 f_finv.
+  + apply: contraNF Hu => /eqP->. exact: mem_closure.
+  + apply: contraNF Hu => /eqP->. exact: mem_closure. 
+Qed.
+
+Lemma n_comp_mergeX (G : hypermap) (x y : G) (xDy : x != y) : 
+  cnode x y (+) cface x y -> n_comp glink (merge x y) = n_comp glink G.
+Proof.
+move => c_xy.
+pose a := closure glink (pred2 x y).
+pose b := closure (@glink (merge x y)) (pred2 x y).
+have eq_b_a : b =i a by apply closure_merged.
+rewrite (n_compC b) (n_compC a) !n_comp_closure2; try exact:glinkC.
+rewrite (n_comp_merge_rest xDy). 
+suff -> : (gcomp : rel G) x y = (gcomp : rel (merge x y)) x y by [].
+apply/idP/idP => _; case: (boolP (cnode x y)) c_xy => /= N F.
+- apply: (@gcompF (merge x y)) => /=. 
+  eapply connect_trans with (finv face x).
+  + apply: fconnect_f_switch => //; first by rewrite cface1 f_finv // cfaceC.
+    by rewrite cface1r f_finv.
+  + apply: connect1 => /=. rewrite eqxx. 
+    by case: (finv face x =P _) => [->|]; rewrite f_finv.
+- apply: (@gcompN (merge x y)) => /=. 
+  eapply connect_trans with (node y). 
+  + apply: connect1 => /=; by rewrite eqxx.
+    apply: fconnect_f_switch => //; by rewrite -?cnode1r -?cnode1. 
+  + exact: gcompN.
+  + exact: gcompF.
+Qed.
+
+Lemma n_comp_mergeG (G : hypermap) (x y : G) : 
+  ~~ gcomp x y -> (n_comp glink (merge x y)).+1 = (n_comp glink G).
+Proof.
+move=> gcNxy. 
+have xDy : x != y by apply: contraNneq gcNxy => ->. 
+pose a := closure glink (pred2 x y).
+pose b := closure (@glink (merge x y)) (pred2 x y).
+have eq_b_a : b =i a by apply closure_merged.
+rewrite (n_compC b) (n_compC a) !n_comp_closure2; try exact:glinkC.
+rewrite gcNxy /= add2n addSn -(n_comp_merge_rest xDy) -/a.
+rewrite [connect _ _ _](_ : _ = true) //.
+apply: (@gcompN (merge x y)). 
+rewrite fconnect_switched => //; last exact: (@nodeI G).
+apply: contraNN gcNxy. exact: gcompN.
+Qed.
+
+Lemma genus_mergeX (G : hypermap) (x y : G) :
+  cnode x y (+) cface x y -> genus (merge x y) = genus G.
+Proof.
+move => cn_cf_xy.
+have xDy : x != y by apply: contraTneq cn_cf_xy => ->; rewrite !connect0.
+have fI := finv_inj faceI; have nI := finv_inj nodeI.
+rewrite /genus /Euler_lhs /= (n_comp_mergeX xDy cn_cf_xy) -/(Euler_lhs G).
+rewrite {1}/Euler_rhs /= !fcard_switch ?inj_eq // 1?eq_sym //; last exact: fI.
+move: cn_cf_xy. rewrite -{2}[x](f_finv faceI) -{2}[y](f_finv faceI) -cface1 -cface1r cfaceC.
+case: (boolP (cnode x y)) => /= => [_ /negbTE->|_ ->]. 
+- rewrite addSnnS prednK //; apply/fcard0P => //; [exact: faceI|by exists x].
+- rewrite -addSnnS prednK //; apply/fcard0P => //; [exact: nodeI|by exists x].
+Qed.
+
+Lemma genus_mergeG (G : hypermap) (x y : G) :
+  ~~ gcomp x y -> genus (merge x y) = genus G.
+Proof.
+move=> gcNxy. 
+have [? ?] := (@nodeI G, @faceI G).
+have fI := finv_inj (@faceI G).
+have xDy : x != y by apply: contraNneq gcNxy => ->. 
+have cxyF : cnode x y = false. apply: contraNF gcNxy. exact: gcompN.
+have fxyF : cface x y = false. apply: contraNF gcNxy. exact: gcompF.
+rewrite /genus /Euler_lhs /= -(n_comp_mergeG gcNxy).
+rewrite doubleS -add2n -addnA -/(Euler_lhs (merge x y)).
+suff -> : Euler_rhs G = (Euler_rhs (merge x y)).+2.
+  by rewrite -[(Euler_rhs (merge x y)).+2]addn2 addnC subnDr.
+rewrite /Euler_rhs !fcard_switch // ?(inj_eq fI) 1?eq_sym //.
+rewrite cxyF. rewrite (@cface1 G) (@cface1r G) !f_finv // cfaceC fxyF /=.
+rewrite -2!addnS; congr (_ + _); rewrite -addnS -addSn !prednK //.
+all: by apply/fcard0P => //; exists x.
+Qed.
+
+Lemma genus_merge (G : hypermap) (x y : G) :
+  ~~ gcomp x y || (cnode x y (+) cface x y) -> genus (merge x y) = genus G.
+Proof. case/orP; [exact: genus_mergeG|exact: genus_mergeX]. Qed.
+
+Lemma merge_planar (G : hypermap) (x y : G) :
+  ~~ gcomp x y || (cnode x y (+) cface x y) -> planar G -> planar (merge x y).
+Proof. by rewrite /planar => /genus_merge->. Qed.
+
+Arguments merge : clear implicits.
+
+
+Section MergeAdjn.
+
+Local Notation "'@cnode[' G ]" := (fconnect (@node G)) (at level 1, format "'@cnode[' G ]").
+Local Notation "'@cface[' G ]" := (fconnect (@face G)) (at level 1, format "'@cface[' G ]").
+Local Notation "'@adjn[' G ]" := (@adjn G) (at level 1, format "'@adjn[' G ]").
+
+Lemma cnode_merge (G : hypermap) (x y u v : G) : 
+  ~~ cnode x y -> 
+  @cnode[merge G x y] u v = 
+  [|| @cnode[G] u v , @cnode[G] u x && @cnode[G] v y | @cnode[G] u y && @cnode[G] v x ].
+Proof. by apply: fconnect_switchE. Qed.
+
+Lemma merge_loopless (D : hypermap) (x y : D) :
+  plain D -> ~~ @cnode[D] x y -> ~~ @adjn[D] x y -> 
+  loopless D -> loopless (merge D x y).
+Proof.
+move => plainD nNxy nAxy ; apply: contraNN => /existsP [z]. 
+rewrite cnode_merge // => /or3P[?|/andP[Z1 Z2]|/andP[Z1 Z2]]; first by apply/existsP; exists z.
+  apply: contraNT nAxy => _. by apply: (adjnI D z); rewrite cnodeC.
+ apply: contraNT nAxy => _. by apply: (adjnI D (edge z)); rewrite cnodeC ?plain_eq.
+Qed.
+
+Lemma mergeC_hiso (G : hypermap) (x y : G) : hiso (merge G x y) (merge G y x).
+Proof. hiso bij_id => // z; exact: (@switchC G x y (@node G) z). Defined.
+
+Lemma adjn_mergeC (G : hypermap) (x y : G) : @adjn[merge G x y] =2 @adjn[merge G y x].
+Proof. by move=> u v; rewrite -(hiso_adjn (mergeC_hiso x y)). Qed.
+
+Variables (D : hypermap) (dx dy : D).
+Variables (plainD : plain D) (llD : loopless D) (dxDxy : dx != dy).
+Let D' := merge D dx dy.
+
+(** [d1] is on one of the merged node cycles *)
+Lemma adjn_merge1 (d1 d2 : D) : ~~ @cnode[D] dx dy -> ~~ @adjn[D] dx dy -> 
+  @cnode[D] d1 dy -> @adjn[D'] d1 d2 = @adjn[D] d2 dx || @adjn[D] d2 dy.
+Proof.
+move=> n_dxy nAdydx d1y.
+have llD' : loopless D' by apply: merge_loopless.
+have dxdy : @cnode[D'] dx dy by rewrite fconnect_switched => //; exact: (@nodeI D). 
+have subDD' : subrel @cnode[D] @cnode[D'] by apply: switch_subrel.
+apply/idP/idP.
+- case/exists_inP => z; rewrite !inE; set z' := edge z => C1.
+  have {d1 d1y C1} Cz : @cnode[D'] dy z. 
+  { apply: connect_trans C1. rewrite cnodeC. exact: switch_subrel d1y. }
+  move: (Cz); rewrite cnode_merge // [_ dy dx]cnodeC (negbTE n_dxy) connect0 /=.    
+  rewrite cnode_merge // [@cnode[D] z' dx]rwF 1?[@cnode[D] z' dy]rwF ?andbF ?orbF.
+  + case/orP => H1 H2; apply/orP; [right|left]; apply/exists_inP; exists (edge z) => //.
+    by rewrite plain_eq. by rewrite plain_eq // inE cnodeC.
+  + apply: contraNN llD' => X; apply/existsP; exists z; rewrite cnodeC.
+    apply: connect_trans Cz. exact: subDD'.
+  + apply: contraNN llD' => X; apply/existsP; exists z; rewrite cnodeC.
+    apply: connect_trans Cz. apply: connect_trans. exact: subDD' X. done.
+- case/orP; case/exists_inP => z; rewrite !inE => d2_z d_ez.
+  + apply/exists_inP; exists (edge z); rewrite inE.
+    * apply: connect_trans (subDD' _ _ d_ez). 
+      apply: connect_trans (subDD' _ _ d1y) _. by rewrite cnodeC.
+    * rewrite plain_eq //. exact: subDD'.
+  + apply/exists_inP; exists (edge z); rewrite inE.
+    * apply: connect_trans (subDD' _ _ d_ez). exact: subDD'.
+    * rewrite plain_eq //. exact: subDD'. 
+Qed.
+
+(** Neither [d1] nor [d2] is on one of the merged node cycles *)
+Lemma adjn_merge2 (d1 d2 : D) : ~~ @cnode[D] dx dy -> ~~ @adjn[D] dx dy ->
+ ~~ @cnode[D] d1 dx -> ~~ @cnode[D] d1 dy -> ~~ @cnode[D] d2 dx -> ~~ @cnode[D] d2 dy -> 
+ @adjn[D'] d1 d2 = @adjn[D] d1 d2.
+Proof.
+move=> n_dxy nAdydx d1x d1y d2x d2y.
+have llD' : loopless D' by apply: merge_loopless.
+have dxdy : @cnode[D'] dx dy by rewrite fconnect_switched => //; exact: (@nodeI D). 
+have subDD' : subrel @cnode[D] @cnode[D'] by apply: switch_subrel.
+apply/exists_inP/exists_inP => -[z]; rewrite !inE.
+- rewrite fconnect_switchE //; last exact: (@nodeI D).
+  rewrite (negbTE d1x) (negbTE d1y) // fconnect_switchE //; last exact: (@nodeI D).
+  rewrite (negbTE d2x) (negbTE d2y) /= !orbF. by exists z.
+- move => d1z d2ez. exists z; apply: switch_subrel => //; exact: (@nodeI D).
+Qed.
+
+
+End MergeAdjn.
+
+(** ** Disjoint Union *)
+
+Arguments inl_inj {A B}.
+Arguments inr_inj {A B}.
+
+Section SumF.
+Variables (T1 T2 : finType) (f1 : T1 -> T1) (f2 : T2 -> T2).
+Notation sumf := (sumf f1 f2).
+Variables (inj_f1 : injective f1) (inj_f2 : injective f2).
+
+Lemma sumf_inj : injective sumf.
+Proof. move => [u|u] [v|v] //= []; by [ move/inj_f1->| move/inj_f2 ->]. Qed.
+
+Lemma sumf_connect_sym : connect_sym (frel sumf).
+Proof. exact: fconnect_sym sumf_inj. Qed.
+
+Lemma closed_sumf_l : fclosed sumf is_inl.
+Proof. by move => [u|u] [v|v]. Qed.
+
+Let csym1 := fconnect_sym inj_f1.
+Let csym2 := fconnect_sym inj_f2.
+
+Lemma adjunction_sumf_inl : fun_adjunction inl sumf f1 is_inl.
+Proof. 
+apply: strict_adjunction closed_sumf_l _ _ _  => //; first exact: inl_inj.
+by apply/subsetP => -[u _|//]; rewrite codom_f.
+Qed.
+
+Lemma adjunction_sumf_inr : fun_adjunction inr sumf f2 [predC is_inl].
+apply: strict_adjunction _ _ _  => //; try exact: inr_inj.
+  by apply/predC_closed/closed_sumf_l.
+by apply/subsetP => -[//|u _]; rewrite codom_f.
+Qed.
+
+Lemma fcard_sumf  :
+  fcard sumf {:T1 + T2}  = fcard f1 T1 + fcard f2 T2.
+Proof.
+pose a (x : T1 + T2) := x : bool.
+have ? := sumf_connect_sym; have ? := fconnect_sym inj_f1; have ? := fconnect_sym inj_f2.
+have ? : fclosed sumf a by move => [u|u] [v|v].
+have ? : fclosed sumf (predC a) by apply: predC_closed.
+rewrite (n_compC a) (adjunction_n_comp _ _ _ _ adjunction_sumf_inl) //.
+by rewrite (adjunction_n_comp _ _ _ _ adjunction_sumf_inr).
+Qed.
+
+Lemma fconnect_sumf_l x y : 
+  fconnect sumf (inl x) (inl y) = fconnect f1 x y.
+Proof. by symmetry; apply: rel_functor adjunction_sumf_inl _ _ _. Qed.
+
+Lemma fconnect_sumf_r x y : 
+  fconnect sumf (inr x) (inr y) = fconnect f2 x y.
+Proof. by symmetry; apply: rel_functor adjunction_sumf_inr _ _ _. Qed.
+
+Lemma fconnect_sumf_lr x y : fconnect sumf (inl x) (inr y) = false.
+Proof.
+apply/negbTE/negP => /connectP[p].
+elim: p x => //= -[x|//] p IHp z /andP[_]; exact: IHp.
+Qed.
+
+Lemma fconnect_sumf_rl x y : fconnect sumf (inr x) (inl y) = false.
+Proof.
+apply/negbTE/negP => /connectP[p].
+elim: p x => //= -[//|x] p IHp z /andP[_]; exact: IHp.
+Qed.
+
+Definition fconnect_sumf := 
+  (fconnect_sumf_l, fconnect_sumf_r, fconnect_sumf_lr, fconnect_sumf_rl).
+
+End SumF.
+
+Lemma sumf_cancel3 T1 T2 (e1 n1 f1 : T1 -> T1) (e2 n2 f2 : T2 -> T2) :
+  cancel3 e1 n1 f1 -> cancel3 e2 n2 f2 -> cancel3 (sumf e1 e2) (sumf n1 n2) (sumf f1 f2).
+Proof. by move => can1 can2 [x|x] /=; rewrite ?can1 ?can2. Qed.
+
+Definition hmap_union (G1 G2 : hypermap) := 
+  Hypermap (sumf_cancel3 (@edgeK G1) (@edgeK G2)).
+
+Declare Scope hmap_scope.
+Notation "G ∔ H" := (hmap_union G H) (at level 20, left associativity) : hmap_scope.
+Bind Scope hmap_scope with hypermap.
+Delimit Scope hmap_scope with H.
+
+Lemma union_genus (G1 G2 : hypermap) :
+  genus (G1 ∔ G2) = genus G1 + genus G2.
+Proof.
+rewrite {1}/genus.
+suff -> : Euler_lhs (G1 ∔ G2) = Euler_lhs G1 + Euler_lhs G2.
+{ have -> : Euler_rhs (G1 ∔ G2) = Euler_rhs G1 + Euler_rhs G2.
+    by rewrite /Euler_rhs !fcard_sumf //; ring.
+  rewrite subnDA -addnBAC -1?addnBA ?Euler_le //.
+  by rewrite halfD -!/(genus _) !even_genusP -2?addnBA // ?subnn !addn0 !odd_double. }
+rewrite /Euler_lhs card_sum (n_compC (fun x : (G1 ∔ G2)%H => x)).
+have ? := glinkC.
+have cl_inl : closed (@glink (G1 ∔ G2)) is_inl by apply: intro_closed => // -[x|x] [y|y].
+have cl_inr := predC_closed cl_inl.
+have inl_adj : @rel_adjunction (G1 ∔ G2)%H G1 (@inl _ _) glink glink is_inl. 
+{ apply: strict_adjunction => //; first exact: inl_inj.
+  apply/subsetP=> -[z _|//]; exact: codom_f. }
+have inr_adj : @rel_adjunction (G1 ∔ G2)%H G2 (@inr _ _) glink glink [predC is_inl].
+{ apply: strict_adjunction => //; first exact: inr_inj.
+  apply/subsetP=> -[//|z _]; exact: codom_f. }
+rewrite (adjunction_n_comp _ _ _ _ inl_adj) ?(adjunction_n_comp _ _ _ _ inr_adj) //.
+by rewrite doubleD -!addnA; congr (_ + _); rewrite [RHS]addnC [#|_| + #|_|]addnC -!addnA. 
+Qed.
+
+Lemma union_planar (G1 G2 : hypermap) : planar (G1 ∔ G2) <-> planar G1 /\ planar G2.
+Proof. rewrite /planar union_genus addn_eq0. by do 2 case (_ == 0) => //=; firstorder. Qed.
+
+Lemma union_plain (G H: hypermap) : plain G -> plain H -> plain (G ∔ H)%H.
+Proof.
+move => plainG plainH; apply/plainP => -[x|x] _ /=.
+  by rewrite (inj_eq inl_inj) plain_eq ?plain_neq.
+by rewrite (inj_eq inr_inj) plain_eq ?plain_neq.
+Qed.
+
+Lemma union_adjn_l (G H : hypermap) (x y : G) :
+  @adjn (G ∔ H)%H (inl x) (inl y) = adjn x y.
+Proof.
+apply/exists_inP/exists_inP.
+- by move=> [[z|z]]; rewrite !inE /= ?fconnect_sumf //; exists z.
+- by move=> [z]; rewrite inE => Z1 Z2; exists (inl z); rewrite !inE /= ?fconnect_sumf.
+Qed.
+
+Lemma union_adjn_r (G H : hypermap) (x y : H) :
+  @adjn (G ∔ H)%H (inr x) (inr y) = adjn x y.
+Proof.
+apply/exists_inP/exists_inP.
+- by move=> [[z|z]]; rewrite !inE /= ?fconnect_sumf //; exists z.
+- by move=> [z]; rewrite inE => Z1 Z2; exists (inr z); rewrite !inE /= ?fconnect_sumf.
+Qed.
+
+Lemma union_adjn_lr (G H : hypermap) (x : G) (y : H) :
+  @adjn (G ∔ H)%H (inl x) (inr y) = false.
+Proof.
+by apply: (introF exists_inP); move => -[[z|z]]; rewrite !inE /= ?fconnect_sumf.
+Qed.
+
+Lemma union_adjn_rl (G H : hypermap) (x : H) (y : G) :
+  @adjn (G ∔ H)%H (inr x) (inl y) = false.
+Proof.
+by apply: (introF exists_inP); move => -[[z|z]]; rewrite !inE /= ?fconnect_sumf.
+Qed.
+
+Definition union_adjn := (union_adjn_l,union_adjn_lr,union_adjn_r, union_adjn_rl).
+
+(** ** Deleting a node (and incident edges) *)
+
+(** [frestrict] restricts a function [T -> T] to a function [sig P ->
+sig P], provided [P] is closed under [f]. *)
+Section FRes.
+Variables (T : Type) (P : pred T) (f : T -> T) (hom_f : {homo f : x / x \in P}).
+
+Definition frestrict (x : sig P) : sig P := let: exist vx Px := x in Sub (f vx) (hom_f Px).
+
+Lemma val_frestrict x : val (frestrict x) = f (val x). by case: x. Qed.
+
+Lemma frestrict_inj : {in P&, injective f} -> injective frestrict.
+Proof.
+move => inj_f x y. move/(f_equal val); rewrite !val_frestrict.
+move/inj_f/val_inj => -> //; exact: valP.
+Qed.
+
+End FRes.
+Lemma fconnect_frestrict (T : finType) (P : pred T) (f : T -> T)  (x y : sig P) 
+  (hom_f : {homo f : x / x \in P}) :
+  fconnect (frestrict hom_f) x y = fconnect f (val x) (val y).
+Proof.
+apply/idP/idP => /iter_findex; move: (findex _ _ _) => n.
+  move<-. elim: n x => [//|n IHn x]. rewrite iterSr. 
+  by apply: connect_trans (connect1 _) (IHn _); rewrite /= val_frestrict.
+move: x y => [x Px] [y Py] /=; rewrite -[exist _ _ _]/(Sub x Px) -[exist _ _ _]/(Sub y Py).
+elim: n x Px y Py => [|n IHn] x Px y Py. 
+  by move => ?; subst y; rewrite (eq_irrelevance Px Py).
+rewrite iterSr => it_n. 
+apply: connect_trans (IHn _ _ _ _ it_n) => [|Pfx] ; first exact: hom_f Px.
+by apply: connect1; rewrite /= -val_eqE.
+Qed.
+
+Section Skip.
+Variables (T : finType) (a : pred T) (f : T -> T).
+
+(** The function [skip p f] behaves like [f], but skips over elements
+that are NOT in [p] (if possible). In the general case, one needs to
+assume that [f x] can reach some element in [p] by iteration. If [f]
+is injective, one can assume [x \in p] instead. *)
+
+Lemma skip_proof x : 
+  [exists n : 'I_(order f (f x)), iter n.+1 f x \in a] -> exists n : nat, iter n.+1 f x \in a.
+Proof. by case/existsP => n; exists n. Qed.
+
+Definition skip (x : T) : T := 
+  match @idP [exists n : 'I_(order f (f x)), iter n.+1 f x \in a] with
+  | ReflectT E => iter (ex_minn (skip_proof E)).+1 f x
+  | ReflectF _ => x
+  end.
+
+Lemma skip_exists' x y : 
+  y \in a -> fconnect f (f x) y -> [exists n : 'I_(order f (f x)), iter n.+1 f x \in a].
+Proof.
+move => y_a c_xy; have:= iter_findex c_xy; rewrite -iterSr => E.
+set n := findex _ _ _ in E.
+have Hn : n < order f (f x) by apply: findex_max.
+apply/existsP; exists (Ordinal Hn); by rewrite E.
+Qed.
+
+Variant skip_spec' x : T -> Type :=
+  SkipSpec' (n:nat) of n < order f (f x) & iter n.+1 f x \in a 
+         & (forall m, iter m.+1 f x \in a -> n <= m) : skip_spec' x (iter n.+1 f x).
+
+
+Lemma skipP' x y : y \in a -> fconnect f (f x) y -> skip_spec' x (skip x).
+Proof.
+move => y_a c_xy; rewrite /skip.
+case: {-}_ / idP => [p|]; last by rewrite (skip_exists' y_a c_xy).
+case: ex_minnP => n N1 N2; constructor; auto. 
+case/existsP : p => -[m Hm] /N2/= ?. exact: leq_trans Hm.
+Qed.
+
+Lemma skip1 x : f x \in a -> skip x = f x.
+Proof. 
+move => fx_a. case: (skipP' fx_a) => // n _ N1 N2.
+move: (N2 0 fx_a). by rewrite leqn0 => /eqP->.
+Qed.
+
+Lemma skip_first x y : 
+  y \in a -> fconnect f (f x) y -> f x \notin a -> skip x = skip (f x).
+Proof.
+move => y_a f_xy fxNa.
+have f_xy' : fconnect f (f (f x)) y. 
+{ move/iter_findex : f_xy. case: (findex _ _ _) => [/= dy|n]. 
+    by rewrite dy y_a in fxNa.
+  rewrite iterSr => <-. exact: fconnect_iter. }
+case: (skipP' y_a f_xy) => n N0 N1 N2.
+case: (skipP' y_a f_xy') => m M0 M1 M2. 
+suff /eqP-> : n == m.+1 by rewrite iterSr.
+rewrite eqn_leq N2 1?iterSr //=.
+destruct n as [|n]; first by rewrite /= (negbTE fxNa) in N1.
+by rewrite ltnS M2 // -iterSr.
+Qed.
+
+Hypothesis inj_f : injective f.
+
+Lemma skip_exists x : x \in a -> [exists n : 'I_(order f (f x)), iter n.+1 f x \in a].
+Proof.
+move => x_a. apply: skip_exists' x_a _. by rewrite fconnect_sym // fconnect1.
+Qed.
+
+Lemma skipE x (x_a : x \in a) : 
+  skip x = iter (ex_minn (skip_proof (skip_exists x_a))).+1 f x.
+Proof.
+rewrite /skip. case: {-}_ / idP => [p|]; last by rewrite (skip_exists x_a).
+by rewrite (bool_irrelevance (skip_exists x_a) p). 
+Qed.
+
+Variant skip_spec x : T -> Type :=
+  SkipSpec (n:nat) of n < order f (f x) & iter n.+1 f x \in a 
+         & (forall m, iter m.+1 f x \in a -> n <= m) : skip_spec x (iter n.+1 f x).
+
+Lemma skipP x (x_a : x \in a) : skip_spec x (skip x).
+Proof. 
+rewrite skipE. set p := skip_exists _. 
+case: ex_minnP => n N1 N2; constructor; auto. 
+case/existsP : p => k Hk. apply: leq_trans (ltn_ord k). exact: N2.
+Qed.
+
+Lemma skip_eq x y n :
+  x \in a -> y \in a -> (forall m : nat, iter m.+1 f x \in a -> n <= m) -> iter n.+1 f x = y -> 
+  skip x = y.
+Proof.
+move => x_a y_a min_n def_y; case: skipP => // m _ M1 M2. 
+suff /eqP -> : m == n by []. by rewrite eqn_leq min_n // M2 // def_y.
+Qed.
+
+
+Lemma iter_inj n : injective (iter n f).
+Proof. move => x y. by elim: n => // n IH /= /inj_f. Qed.
+
+Lemma skip_hom : {homo skip : x / x \in a}.
+Proof. move => x in_a. by case: skipP. Qed.
+
+Lemma skip_inj : {in a&, injective skip}.
+Proof.
+move => x y x_a y_a. 
+case: (skipP x_a) => n _ N1 N2. case: (skipP y_a) => m _ M1 M2 eqI.
+suff/eqP ? : n == m by subst; apply: iter_inj eqI.
+case: (ltngtP n m) => // n_lt_m. (* TODO: proper symmetry reasoning *)
+- have eq_x : x = iter (m - n.+1).+1 f y. 
+  { rewrite subnSK //. rewrite -(subnK (ltnW n_lt_m)) -addnS addnC iter_add in eqI.
+    exact: iter_inj eqI. }
+  rewrite eq_x in x_a. move: (M2 _ x_a). destruct m => //. by rewrite subSS ltn_subrR.
+- have eq_y : y = iter (n - m.+1).+1 f x. 
+  { rewrite subnSK //. rewrite -(subnK (ltnW n_lt_m)) -addnS addnC iter_add in eqI.
+    symmetry. exact: iter_inj eqI. }
+  rewrite eq_y in y_a. move: (N2 _ y_a). destruct n => //. by rewrite subSS ltn_subrR.
+Qed.
+
+Lemma fconnect_skip: {in a&, fconnect skip =2 fconnect f}.
+Proof.
+move => x y x_a y_a; apply/idP/idP. 
+- move/iter_findex<-; move: (findex _ _ _) => n; elim: n x x_a => //= n IHn x x_a.
+  apply: connect_trans (IHn _ x_a) _.
+  case: skipP => [|m *]; last exact: fconnect_iter.
+  by apply/iter_in => //; apply: skip_hom.
+- move/iter_findex => E; rewrite -{}E in y_a *.
+  move: (findex _ _ _) y_a => n. 
+  have [m Hm] := ubnP n; elim: m n Hm x x_a {y} => // m IHm [//|n] /ltnSE n_leq_m x x_a iter_n_f.
+  case: (boolP [exists k : 'I_n, (iter k.+1 f x \in a)]).
+  + case/existsP => [[k Hk] iter_k_f]. 
+    apply: connect_trans (IHm _ _ _ _ iter_k_f) _ => //. by apply: leq_trans n_leq_m.
+    apply: connect_trans (IHm (n.+1 - k.+1) _ _ _ _) _ => //. 
+    * apply: leq_trans n_leq_m. by rewrite subSS ltnS leq_subr.
+    * by rewrite -iter_add subnK // ltnW.
+    * by rewrite -iter_add subnK // ltnW.
+  + move/existsPn => Hn. rewrite (_ : iter n.+1 f x = skip x) ?fconnect1 //.
+    case: skipP => // k _ K1 K2. rewrite (_ : n = k) //; apply/eqP. 
+    rewrite eqn_leq K2 // andbT leqNgt. 
+    apply: contraTN K1 => Hk; exact: (Hn (Ordinal Hk)).
+Qed.
+
+End Skip.
+Arguments skip_first [T a f x] y.
+
+(** useful? *)
+Lemma finv_skip (T : finType) (a : pred T) (f : T -> T) : 
+  injective f -> {in a, finv (skip a f) =1 skip a (finv f)}.
+Abort.
+
+Section DelNode.
+Variables (G : hypermap) (z : G).
+
+Let N := fclosure edge (cnode z).
+
+Definition del_dart := { x : G | x \notin N }.
+
+Lemma del_edge_hom : {homo edge : x / x \notin N}.
+Proof. 
+move => x. by rewrite /N -(closure_closed cedgeC _ (eqxx _)).
+Qed.
+
+Definition del_node_hom : {homo skip [predC N] node : x / x \notin N}.
+Proof. exact: skip_hom. Qed.
+
+(** TOTHINK: This defintion makes no assumptions on the hypermap
+(e.g., loopless, plain, etc.). However, the face permutation is
+completely useless. This makes it hard to prove anything interesting
+(e.g., preservation of planarity) for the general case. *)
+
+Definition del_node_face_ := finv (frestrict del_node_hom) \o finv (frestrict del_edge_hom).
+
+Lemma del_node_can3: 
+  cancel3 (frestrict del_edge_hom) (frestrict del_node_hom) del_node_face_.
+Proof. 
+move => x; rewrite /del_node_face_ /= finv_f ?f_finv //.
+- by apply/frestrict_inj/skip_inj.
+- apply/frestrict_inj. exact: in2W edgeI.
+Qed.
+
+Definition del_node := Hypermap del_node_can3.
+
+Hypothesis plainG : plain G.
+
+Let NP x : reflect (cnode z x || cnode z (edge x)) (x \in N).
+Proof using plainG.
+apply: (iffP (closureP _ _ _)) => [[y /=]|]; last first.
+  by case/orP; [exists x|exists (edge x); rewrite // -cedge1r].
+by rewrite plain_orbit // !inE => zy /pred2P [?|?]; subst y; rewrite zy.
+Qed.
+
+Let edgeN x : edge x \in N = (x \in N). 
+Proof using. symmetry. apply: closure_closed => //=. exact: cedgeC. Qed.
+
+Lemma del_node_cnode (u v : del_node) : cnode u v = cnode (val u) (val v).
+Proof. by rewrite fconnect_frestrict fconnect_skip //; apply: valP. Qed.
+
+Lemma del_node_adjn (u v : del_node) : adjn u v = adjn (val u) (val v).
+Proof using plainG.
+apply/exists_inP/exists_inP => -[d]; rewrite !inE.
+  by rewrite !del_node_cnode val_frestrict; exists (val d).
+have [dN|dNN] := boolP (d \in N); last first.
+  by exists (Sub d dNN); rewrite inE del_node_cnode ?val_frestrict.
+move => n_u_d n_v_d; case:notF.
+have/NP/orP[n_z_d|n_z_ed] := dN.
+- apply: contraNT (valP u) => _. apply: mem_closure.
+  by rewrite inE (connect_trans n_z_d _) // cnodeC.
+- apply: contraNT (valP v) => _. apply: mem_closure.
+  by rewrite inE (connect_trans n_z_ed _) // cnodeC.
+Qed.
+
+Definition del_node_face x := 
+  if face x \in N then finv node (face x) else face x.
+
+Hypothesis llG : loopless G.
+
+Definition simple_hmap := forall x y : G, x != y -> cnode x y -> ~~ cnode (edge x) (edge y).
+Hypothesis simple : simple_hmap.
+
+Let simple' :  forall x y : G , x != y -> cnode x y -> ~~ cnode (face x) (face y).
+Proof. by move=> x y xDy n_xy; rewrite cnode1 cnode1r !plain_eq' // simple. Qed.
+
+Hypothesis deg2 : forall x : G, node x == x = false.
+
+(* the following forbids two things:
+   - parallel edges having one end at the removed node (would result in n-neighbors in N)
+   - degreee 1 neighbors of the removed node (would consist of a single element in N) *)
+Lemma del_node_neighbor1 x : ~~cnode z x -> x \in N -> node x \notin N.
+Proof. 
+move=> /negPf n_zxF /NP; rewrite n_zxF /= => n_z_ex. 
+apply: contraTN isT => /NP; rewrite -cnode1r n_zxF /= => n_z_enx.
+have /negbT := deg2 x; rewrite -(inj_eq edgeI) => /simple.
+by rewrite !plain_eq // (connect_trans _ n_z_ex) cnodeC // -cnode1r connect0 => /(_ isT).
+Qed.
+
+Let del_node_neighbor1' x : ~~cnode z x -> x \in N -> finv node x \notin N.
+Proof.
+move => Hz; apply: contraTN => /del_node_neighbor1. 
+by rewrite cnode1r !f_finv //; apply. 
+Qed.
+
+Arguments skipP [T a f] _ [x] _, [T] a [f] _ [x] _.
+
+Let skip2 x : x \notin N -> node x \in N -> skip [predC N] node x = node (node x).
+Proof. 
+move => xN nxN. 
+have xnZ : ~~ cnode z (node x). rewrite -cnode1r. apply: contraNN xN. exact: mem_closure.
+have nnxN := del_node_neighbor1 xnZ nxN. 
+case: (skipP [predC N] nodeI xN) => n _ N1 N2. 
+suff/eqP -> : n == 1 by [].
+rewrite eqn_leq N2 //= lt0n. by apply: contraNneq N1 => ->.
+Qed.
+
+Lemma del_face_hom : {homo del_node_face : x / x \notin N}.
+Proof. 
+move => x xN;rewrite /del_node_face; case: (boolP (face x \in N)) => //.
+apply: del_node_neighbor1'. apply: contraNN xN. rewrite cnode1r plain_eq' // -edgeN. exact: mem_closure.
+Qed.
+
+Lemma del_node_faceE : @face del_node =1 (frestrict del_face_hom).
+Proof.
+suff: cancel3 (frestrict del_edge_hom) (frestrict del_node_hom) (frestrict del_face_hom).
+{ move/canF_sym. apply: inj_can_eq (@faceK del_node) _. by move => x y /edgeI/nodeI. }
+move => x. apply/val_inj; rewrite !val_frestrict /del_node_face. 
+case: (boolP (face (edge (val x)) \in N)) => H.
+- have Hz : ~~ cnode z (face (edge (val x))). 
+  { apply: contraNN (valP x). rewrite cnode1r edgeK. exact: mem_closure. }
+  have H' := del_node_neighbor1' Hz H. by rewrite skip2 // f_finv // edgeK.
+- rewrite skip1 // edgeK //. exact: valP.
+Qed.
+
+Lemma del_node_plain : plain del_node.
+Proof.
+have pG := plainP plainG; apply/plainP => x _; split. 
+- apply/val_inj => /=. rewrite !val_frestrict. by apply pG.
+- rewrite -(inj_eq val_inj) !val_frestrict. by apply pG.
+Qed.
+
+Lemma del_node_loopless : loopless del_node.
+Proof using llG.
+move/existsPn : (llG) => llG'; apply/existsPn => x.
+apply: contraNN (llG' (val x)) => loop_x.
+suff S (u v : del_node) : cnode u v -> cnode (val u) (val v).
+{ by rewrite -[X in cnode _ X](val_frestrict del_edge_hom) S. }
+rewrite /= -(@fconnect_skip _ [predC N] _ nodeI); try exact: valP.
+by apply: homo_connect => {u v} u v /= /eqP<-; rewrite val_frestrict. 
+Qed.
+
+Lemma wheel_proof x : cnode z x -> face x \notin N.
+Proof using deg2 llG plainG simple.
+have F := loopless_face _ plainG llG; rewrite cnodeC.
+move => n_xz; apply: contraTN isT => /NP.
+have/negPf -> /= : ~~ cnode z (face x). 
+  by apply: contraNN (F x); apply: connect_trans.
+set y := edge _ => n_zy.
+have E : edge y = face x by rewrite plain_eq.
+have [xy|xDy] := eqVneq x y.
+  by rewrite -(deg2 (face x)) plain_eq' // {1}xy E.
+have /simple -/(_ xDy): cnode x y by apply: connect_trans n_zy.
+by rewrite plain_eq // cnode1r plain_eq' // connect0.
+Qed.
+
+Let z' : del_node := Sub (face z) (@wheel_proof z (connect0 _ _)).
+Let inD (x : G) : del_node := insubd z' x.
+
+(** This follows if [G] is 2-connected and planar, see [hcycle.v] *)
+Hypothesis cycleG : forall x y : G, x != y -> cface x y -> ~~ cnode x y.
+
+Let blG : bridgeless G.
+Proof.
+apply/negP => /existsP [x]; rewrite cface1r -[face _](finv_f nodeI) edgeK.
+by move/cycleG; rewrite -(inj_eq nodeI) f_finv // deg2 fconnect_finv => /(_ isT).
+Qed.
+
+Lemma cycleG' : forall x y : G , x != y -> cnode x y -> ~~ cface (edge x) (edge y).
+Proof. 
+move => x y xDy; apply: contraTN; rewrite cface1 cface1r => /cycleG.
+rewrite (inj_eq faceI) (inj_eq edgeI) => /(_ xDy).
+by rewrite cnode1 cnode1r !edgeK.
+Qed.
+
+(* TOTHINK: is deg2 really necessary? *)
+Lemma arity3 (x : G) : 2 < arity x.
+Proof using llG plainG deg2 simple.
+rewrite 1!ltn_neqAle ltnNge [2 != _]rwT /=.
+- have:= loopless_face x plainG llG.
+  apply: contraNN => /card_le1_eqP /(_ x) A.
+  by rewrite [face x]A // inE -?cface1r.
+- move/negbT/simple : (deg2 (face x)); rewrite -cnode1 connect0 => /(_ isT).
+  apply: contraNneq => ar2; rewrite faceK -plain_eq' // -cnode1r.
+  by rewrite -[face _]/(iter 2 face x) ar2 iter_face_arity.
+Qed.
+
+Lemma iter0 (T : Type) (f : T -> T) x : iter 0 f x = x. Proof. by []. Qed.
+
+Lemma homo_fpath_in {T T' : eqType} (h : T -> T') (f : T -> T) (f' : T' -> T') x s :  
+  {in belast x s, forall x : T, h (f x) = f' (h x)}  ->
+  fpath f x s -> fpath f' (h x) [seq h i | i <- s].
+Proof. 
+elim: s x => //= u s IH x /all_cons [Hx {}/IH IH] /andP [/eqP fx path_s].
+by rewrite -Hx fx IH ?eqxx.
+Qed.
+
+
+
+Lemma fpath_sub_belast (T : eqType) (f : T -> T) x (s : seq T) (p : {pred T}) :
+  fpath f x s -> {subset x::s <= p} -> {in belast x s, forall y, p (f y)}.
+Proof.
+rewrite -[{subset _ <= _}]/({in x::s, forall y, p y}) !(rwP allP).
+elim: s x => //= a s IHs x /andP [/eqP->] pth_s /and3P [_ pa all_s] /=. 
+by rewrite pa IHs.
+Qed.
+
+Lemma wheel_segment x : cnode z x -> cface (inD (face x)) (inD (face (node x))).
+Proof.
+move=> n_z_x. 
+have [xN nxN] : face x \notin N /\ face (node x) \notin N. 
+  by split; apply: wheel_proof; rewrite -?cnode1r.
+pose enx := edge (node x).
+have enx_fx : enx = finv face x by apply: faceI; rewrite nodeK f_finv.
+have f_x_enx : cface x enx by rewrite /enx cface1r nodeK.
+have enxN : enx \in N by apply/NP; rewrite /enx plain_eq // -cnode1r n_z_x.
+have [o orbit_fx] : exists o, orbit face (face x) = face x :: o ++ [:: enx; x].
+{ have/(orbit_rot_iter 2 faceI):= (orbit_prefix (arity3 enx)).
+  rewrite !iterS !iter0 !trajectS [traject _ _ 0]/= [drop]lock.
+  rewrite !(rot1_cons,rcons_cat) /= -/cat enx_fx !f_finv // rcons_cat.
+  by move->; eexists. }
+have subF : {subset [predI cface x & N] <= [:: enx; x] }.
+{ move => v; rewrite !inE => /andP[f_x_v /NP /orP[n_z_v|n_z_ev]].
+  - rewrite [v == x]rwT // eq_sym; apply: wlog_neg => xDv.
+    have := cycleG xDv f_x_v. by rewrite (connect_trans _ n_z_v) // cnodeC.
+  - rewrite [v == enx]rwT //= enx_fx -(inj_eq faceI) f_finv // eq_sym.
+    have A : cnode x (edge v) by apply: connect_trans n_z_ev; rewrite cnodeC.
+    rewrite -plain_eq' // -cnode1r in A.
+    rewrite cface1r in f_x_v. 
+    apply: contraTT A => eqN. exact: cycleG f_x_v. }
+have subN : {in face x :: o, forall y, y \notin N}.
+{ move=> y Hy; apply: contraTN (orbit_uniq face (face x)) => yN.
+  rewrite orbit_fx -cat_cons cat_uniq [has _ _]rwT //; apply/hasP; exists y => //.
+  apply: subF; rewrite !inE /= yN cface1 fconnect_orbit orbit_fx.
+  by rewrite -cat_cons mem_cat Hy. }
+pose w := last (face x) o.
+have [fpath_o face_w] : fpath face (face x) o /\ face w = enx.
+{ have:= cycle_orbit faceI (face x). rewrite orbit_fx /cycle rcons_path cat_path /=.
+  by rewrite -/w andbT => /andP[/and3P[-> /eqP->]]. }
+have subN' : {in belast (face x) o, forall y, face y \notin N} 
+  by apply: fpath_sub_belast fpath_o subN.
+have wN : w \notin N by apply/subN; rewrite mem_last.
+apply: (@connect_trans _ _ (inD w)); last first.
+- rewrite /inD !insubdT. apply: connect1. 
+  rewrite /= -[del_node_face_]/(@face del_node) del_node_faceE. (* bad simpl behavior *)
+  rewrite -val_eqE /= /del_node_face face_w enxN.
+  by rewrite /enx -plain_eq' // finv_f.
+- apply/connectP; exists (map inD o); last by rewrite last_map.
+  apply: homo_fpath_in fpath_o => y y_o. 
+  rewrite /inD insubdT => [|fyN]; first exact/subN'.
+  rewrite insubdT => [|yN]; first exact/subN/mem_belast.
+  apply/val_inj; by rewrite del_node_faceE /del_node_face /= (negPf fyN).
+Qed.
+
+Lemma neighbor_face_aux x : cnode z x -> cface (inD (face z)) (inD (face x)).
+Proof.
+case/connectP => p pth_p ->; elim/last_ind: p pth_p => // p y IH. 
+rewrite last_rcons rcons_path => /andP[A /eqP <-].
+by apply: connect_trans (IH A) _; apply: wheel_segment; apply/connectP; exists p.
+Qed.
+
+Lemma del_node_adjn_face x : 
+  adjn z x -> exists d' : del_node , d' \in orbit face z' /\ cnode (val d') x.
+Proof.
+case/exists_inP => y; rewrite !inE => n_z_y n_x_ey.
+exists (Sub (face y) (wheel_proof n_z_y)); split. 
+- rewrite -fconnect_orbit /z'; do 2 move: (wheel_proof _) => ?.
+  by have:= neighbor_face_aux n_z_y; rewrite /inD !insubdT.
+- by rewrite /= cnode1 plain_eq' // cnodeC.
+Qed.
+
+End DelNode.
+
+
+
+
+Section sub_planar.
+
+
+Set Bullet Behavior "Strict Subproofs".
+
+Lemma skip_skip1 (G : hypermap) (p : pred G) (z : G) (f : G -> G) (injf : injective f) (x : G) (xDz : x != z) :
+  let G' := WalkupF z in
+  let p' := fun x : G' => p (val x) in 
+  ~~ p z -> p x -> skip p f x = sval (skip p' (@walkup.skip (permF G) z f injf) (Sub x xDz)).
+Proof.
+move => G' p' npz px. 
+symmetry. 
+case: skipP => //. exact: inj_skip.
+move => n _ N1 N2.
+have [y Y1 Y2] : exists2 y, p y & fconnect f (f x) y. 
+{ exists x => //. by rewrite -same_fconnect1. }
+elim: n x xDz {px} Y2 N1 N2 => [|n IHn] x xDz Y2  N1 N2.
+- rewrite /=. case: (altP (f x =P z)) => [EQ|NEQ]. 
+  + rewrite (skip_first y) // EQ // skip1 //. 
+    move: N1. by rewrite /walkup.skip unfold_in /= EQ eqxx.
+  + rewrite skip1 //. move: N1. by rewrite /walkup.skip unfold_in /= (negbTE NEQ).
+- rewrite iterSr. set wfx := walkup.skip _ _. 
+  have npfx : ~~ p' wfx. apply/negP => pfx. move: (N2 0) => /=. by case/(_ _)/Wrap. 
+  pose fx := (if f x == z then f z else f x).
+  rewrite [n.+1]lock /wfx {2}/walkup.skip. move: (skip_subproof _ _) => /= fxDz.
+  rewrite -[exist _ _ _]/(Sub fx fxDz). rewrite -lock IHn.
+  + rewrite /fx. case: (altP (f x =P z)) => [EQ|NEQ]; last first.
+    * rewrite [RHS](skip_first y) //. 
+      apply: contraNN npfx. by rewrite /wfx/walkup.skip/p'/= (negbTE NEQ).
+    * rewrite [RHS](skip_first y) // ?EQ //. 
+      rewrite [RHS](skip_first y) //. by rewrite -EQ -same_fconnect1.
+      apply: contraNN npfx. by rewrite /wfx/walkup.skip/p'/= EQ eqxx.
+  + rewrite /fx. case: (altP (f x =P z)) => [EQ|NEQ]; last first.
+    * by rewrite -same_fconnect1. 
+    * by rewrite -EQ -2!(same_fconnect1 injf).
+  + rewrite [Sub fx fxDz](_ : _ = wfx) /wfx -?iterSr //. exact: val_inj.
+  + move => m. rewrite [Sub fx fxDz](_ : _ = wfx) /wfx -?iterSr. apply: N2. exact: val_inj.
+Qed.
+
+(** Any sub-map whose edge and node permutations only skip over the
+removed darts has at most the genus of the original map, because this
+only results in merging faces. Indeed, every such hypermap can be
+obtained (up to isomporphism) by removing the darts one-by-one using
+the [WalkupF] operation. *)
+Theorem sub_genus (G : hypermap) (p : pred G) (e n f : sig p -> sig p) (can3enf : cancel3 e n f) :
+  let H := Hypermap can3enf in
+  (forall (x : H), val (edge x) = skip p edge (val x)) ->
+  (forall (x : H), val (node x) = skip p node (val x)) -> 
+  genus H <= genus G.
+Proof.
+elim/card_ind : G p e n f can3enf => G IH p e n f can3enf H sameE sameN.
+case: (boolP [forall x, p x]) => [/forallP all_p|/forallPn [z npz]].
+- suff I : hiso H G by rewrite (hiso_genus I).
+  hiso (subT_bij all_p).
+  + move => x /=; rewrite sameE skip1 //; exact: all_p.
+  + move => x /=; rewrite sameN skip1 //; exact: all_p.
+- pose G' := WalkupF z.
+  apply: (@leq_trans (genus G')); last exact: le_genus_WalkupF.
+  pose p' := (fun  x : G' =>  p (val x)).
+  have skip_edge := @skip_hom _ p' _ (@edgeI G').
+  have skip_node := @skip_hom _ p' _ (@nodeI G').
+  pose e' := frestrict skip_edge.
+  pose n' := frestrict skip_node.
+  pose f' := finv n' \o finv e'. 
+  have can3enf' : cancel3 e' n' f'. 
+  { move => x. rewrite /f'/= finv_f ?f_finv //. 
+    - apply/frestrict_inj/skip_inj/(@nodeI G').
+    - apply/frestrict_inj/skip_inj/(@edgeI G'). }
+  (* [H] and [Hypermap can3enf'] are the same up to sigma-nesting *)
+  suff I : hiso H (Hypermap can3enf').
+  { rewrite (hiso_genus I).
+    (apply: leq_trans; last apply: (IH G' _ p' e' n' f' can3enf')) => //.
+    - by rewrite /G' /WalkupF /= (card_S_Walkup z). 
+    - by case.
+    - by case. }
+  have fwd_proof1 (x : sig p) : val x != z by apply: contraTneq (valP x) => ->.
+  have fwd_proof2 (x : sig p) : p' (Sub (val x) (fwd_proof1 x)) by exact: (valP x).
+  pose i_fwd (x : sig p) : sig p' := Sub _ (fwd_proof2 x).
+  have bwd_proof (x : sig p') : p (val (val x)) by apply: (valP x).
+  pose i_bwd (x : sig p') : sig p := Sub _ (bwd_proof x).
+  have can_fwd : cancel i_fwd i_bwd by move => x; apply: val_inj.
+  have can_bwd : cancel i_bwd i_fwd by move => x; do 2 apply: val_inj.
+  hiso (Bij can_fwd can_bwd).
+  * case => x px /=. do ! apply: val_inj => /=. rewrite sameE /=.
+    move: (fwd_proof1 _) => /= xDz; rewrite -[exist _ _ _]/(Sub x xDz). 
+    exact: skip_skip1.
+  * case => x px /=. do ! apply: val_inj => /=. rewrite sameN /=.
+    move: (fwd_proof1 _) => /= xDz; rewrite -[exist _ _ _]/(Sub x xDz). 
+    exact: skip_skip1.
+Qed.
+
+Variables (G : hypermap) (p : pred G) (e n f : sig p -> sig p).
+Hypothesis can3enf : cancel3 e n f.
+
+Let H := Hypermap can3enf.
+
+(** relative order of remaining darts in e- and n-cycles remains unchanged *)
+Hypothesis sameE : forall (x : H), val (edge x) = skip p edge (val x).
+Hypothesis sameN : forall (x : H), val (node x) = skip p node (val x).
+
+Lemma sub_planar : planar G -> planar H.
+Proof. rewrite /planar -!leqn0; exact/leq_trans/sub_genus. Qed.
+
+End sub_planar.
+
+Lemma del_node_planar (G : hypermap) (z : G) :
+  planar G -> planar (del_node z).
+Proof.
+apply: sub_planar; last by move => x; rewrite val_frestrict.
+case => x Nx /=. rewrite skip1 // unfold_in -fclosed1 //. 
+exact/closure_closed/cedgeC.
+Qed.
+
+(** ** Adding an Edge. *)
+
+(** [h_add_edge x y] connects [cnode x] and [cnode y] with an edge. The
+darts of this edge [IcpX] and [IcpXe] are added to the nodes after [x]
+and [y]. If [x] and [y] lie on a common f-cycle or on disconncted
+components, this preserves planarity *)
+Arguments IcpX {A}.
+Arguments IcpXe {A}.
+
+Section AddEdge.
+Variables (G : hypermap) (x y : G).
+
+Definition add_edge_edge (z : ecp_dart G) : ecp_dart G := 
+  match z with 
+  | IcpX => IcpXe
+  | IcpXe => IcpX
+  | Icp z' => Icp (edge z')
+  end.
+
+Definition add_edge_node (z : ecp_dart G) : ecp_dart G := 
+  match z with 
+  | IcpX => Icp (node x)
+  | IcpXe => Icp (node y)
+  | Icp z' => if z' == x then IcpX else 
+             if z' == y then IcpXe else Icp (node z') 
+  end.
+
+Definition add_edge_face (z : ecp_dart G) : ecp_dart G := 
+  match z with 
+  | IcpX => Icp y
+  | IcpXe => Icp x
+  | Icp z' => if face z' == x then IcpX else 
+             if face z' == y then IcpXe else Icp (face z')
+  end.
+
+Hypothesis xDy : x != y.
+
+Lemma add_edge_can3 : cancel3 add_edge_edge add_edge_node add_edge_face.
+Proof.
+case => [||z]; rewrite /= ?eqxx ?[y == x]eq_sym ?(negbTE xDy) //.
+case: (altP (face (edge z) =P x)) => /= [<-|Dx]; first by rewrite edgeK.
+case: (altP (face (edge z) =P y)) => /= [<-|Dy]; first by rewrite edgeK.
+by rewrite (negbTE Dx) (negbTE Dy) edgeK.
+Qed.
+
+Definition h_add_edge := Hypermap add_edge_can3.
+
+Let H := h_add_edge.
+
+Fact add_edge_node_x : node (Icp x : H) = IcpX.
+Proof. by rewrite /= eqxx. Qed.
+Fact add_edge_node_y : node (Icp y : H) = IcpXe.
+Proof. by rewrite /= eqxx eq_sym (negbTE xDy). Qed.
+
+(** The rest of this section is about proving that adding an edge
+across a face (i.e., splitting a face) preserves planarity. To this
+end, we show that (up to isomorphim) [G] can be obtained from [H] by a
+double WalkupF operation. The second operation is degenerate: after
+removing [IcpX], [IcpXe] has an e-loop. Thus, all three Walkup
+operations coincide and we can use WalkupE, which involves no
+permutaion of the hypermap components *)
+
+Let SXe : IcpXe != IcpX :> H. done. Qed.
+Definition G' := @WalkupE (WalkupF (IcpX : H)) (Sub IcpXe SXe).
+
+Let S (z : G) : Icp z != IcpX. done. Qed.
+
+Definition i (z : G) : G' := Sub (Sub (Icp z) (S z)) SXe.
+Definition i_inv (z : G') : G := if val (val z) is Icp i then i else x.
+
+Let vvE (z : G') : exists z', val (val z) = Icp z'. 
+Proof. move: z; (do 3 case) => //= a. by exists a. Qed.
+
+Let can_fwd : cancel i_inv i. 
+Proof.
+move => u; case: (vvE u) => u' E; rewrite /i /i_inv E.
+do 2 apply: val_inj => /=. by symmetry.
+Qed.
+
+Let can_bwd : cancel i i_inv. done. Qed.
+
+Let com_i_node u : i (node u) = node (i u).
+Proof.
+do 2 apply/val_inj; rewrite /= /walkup.skip /= !fun_if /=.
+move: (skip_subproof _ _) => /=.
+by case: (altP (u =P x)) => [->//|uDx]; case: (altP (u =P y)) => [->|].
+Qed.
+
+Let com_i_edge u : i (edge u) = edge (i u). Proof. by do 2 apply: val_inj. Qed.
+
+Definition h_add_edge_iso : hiso G G' :=
+  let I := Bij can_bwd can_fwd in
+  @Hiso G G' I com_i_edge com_i_node.
+
+(** this is [~~ cross_edge (IcpX : H)] for WalkupF (IcpX : H) ] *)
+Lemma add_edge_no_cross : cface x y -> ~~ cface (IcpX : H) (IcpXe : H).
+Proof.
+move => f_x_y; rewrite /= -fconnect_switched //; last exact: (@faceI H).
+rewrite same_fconnect1 /=; last by apply/switch_inj/(@faceI H).
+rewrite -[y](f_finv faceI) -same_fconnect1_r // in f_x_y.
+have := iter_findex (f_x_y).
+have Hx: forall m, iter m.+1 face x = x -> findex face x (finv face y) <= m. 
+{ move => m Ex. rewrite -ltnS.
+  have L : looping face x m.+1 by rewrite /looping Ex /= inE eqxx.
+  apply: leq_trans (order_le_looping L). exact: findex_max. }
+move: (findex _ _ _) Hx => n Hx In.
+elim: n {-3}x In Hx => [/= z|n IHn z In Hx]. 
+- move => Ez _. apply: connect1 => /=. 
+  by rewrite Ez f_finv // eqxx [_ == x]eq_sym (negbTE xDy).
+- rewrite iterSr in In. move/IHn in In.
+  rewrite same_fconnect1 /=; last by apply/switch_inj/(@faceI H).
+  have/negbTE -> : face z != x.  move: (Hx 0). by apply: contraPneq => /= -> /(_ erefl).
+  case:(altP (face z =P y)) => // fzy. apply In => m. rewrite -iterSr. by move/Hx.
+Qed.
+
+Lemma add_edge_genus : cface x y -> genus H = genus G.
+Proof.
+move => f_x_y; rewrite (hiso_genus h_add_edge_iso) /G' /H. 
+rewrite genus_WalkupE_eq; last by left.
+rewrite genus_walkupF_eq //. exact: add_edge_no_cross.
+Qed.
+
+Lemma add_edge_planar : cface x y -> planar G -> planar h_add_edge.
+Proof. by move=> f_x_y; rewrite /planar add_edge_genus. Qed.
+
+Let Ico_inj : injective (@Icp G). by move => ? ? []. Qed.
+
+Lemma add_edge_cnodeE u v : cnode (Icp u : H) (Icp v) = cnode u v.
+Proof.
+apply/idP/idP; case/connectP => p.
+- elim/(size_ind (@size H)) : p u => -[/= _ u _ [->] //|/= z p IH u].
+  have [fuEx /andP[/eqP <-] {z}|fuDx] := eqVneq u x. 
+  + case: p IH => [|z p] //= IH => /andP[/eqP<-] {z}. 
+    by rewrite cnode1 fuEx; apply: IH.
+  + have [fuEy /andP[/eqP <-] {z}|fuDy] := eqVneq u y. 
+    * case: p IH => [|z p] //= IH => /andP[/eqP<-] {z}. 
+      by rewrite cnode1 fuEy; apply: IH.
+    * case: z => [||z]; rewrite // inj_eq // => /andP [/eqP fu_z pth_p lst_p].
+    rewrite cnode1 fu_z. exact: IH pth_p lst_p.
+- elim: p u => //= [u _ -> //|z p IHp u /andP[/eqP fu_z] pth_p lst_p].
+  have ? := @nodeI h_add_edge; rewrite same_fconnect1 //=.
+  have [fu_x|_] := eqVneq u x; first by rewrite same_fconnect1 //= -fu_x fu_z; exact: IHp.
+  have [fu_y|_] := eqVneq u y; first by rewrite same_fconnect1 //= -fu_y fu_z; exact: IHp.
+  by rewrite fu_z; exact: IHp.
+Qed.
+
+Lemma add_edge_adjn u v : 
+  adjn (Icp u : H) (Icp v) = 
+  [|| adjn u v , cnode u x && cnode v y | cnode u y && cnode v x].
+Proof.
+apply/exists_inP/idP => [[[||z]]|]; rewrite ?inE; last case/or3P.
+- by rewrite [_ (Icp u) _]cnode1r [_ (Icp v) _]cnode1r !add_edge_cnodeE -!cnode1r => -> ->.
+- by rewrite [_ (Icp u) _]cnode1r [_ (Icp v) _]cnode1r !add_edge_cnodeE -!cnode1r => -> ->.
+- rewrite !add_edge_cnodeE => ? ?; rewrite (_ : adjn u v = true) //.
+  by apply/exists_inP; exists z.
+- by case/exists_inP => z; rewrite !inE -!add_edge_cnodeE => ? ?; exists (Icp z).
+- rewrite -!add_edge_cnodeE [_ _ (Icp x)]cnode1r [_ _ (Icp y)]cnode1r /=.
+  rewrite !eqxx eq_sym (negbTE xDy) => /andP [? ?]. by exists IcpX.
+- rewrite -!add_edge_cnodeE [_ _ (Icp x)]cnode1r [_ _ (Icp y)]cnode1r /=.
+  rewrite !eqxx eq_sym (negbTE xDy) => /andP [? ?]. by exists IcpXe.
+Qed.
+
+Lemma add_edge_cnodeXXe : cnode (IcpX : H) IcpXe = cnode x y.
+Proof. by rewrite cnode1 cnode1r add_edge_cnodeE -cnode1 -cnode1r. Qed.
+
+Lemma add_edge_orbitXe : cface x y ->
+  orbit face (IcpXe : H) = IcpXe :: [seq Icp z | z <- arc (orbit face x) x y].
+Proof.
+set face' := add_edge_face; have faceI' : injective face' by apply: (@faceI H).
+move=> cface_xy; rewrite arc_orbit // /orbit -orderSpred -findex_finv /=.
+congr (_ :: _); rewrite -findex_f ?fconnect_finv //= f_finv // -/face'.
+have F n :  n < findex face x y -> iter n face' (Icp x) = Icp (iter n face x).
+{ elim: n => // n IHn lt_n_y. 
+  rewrite iterS IHn 1?ltnW //= -iterS !ifF //.
+  - by apply:negPf; apply: before_findex.
+  - apply: contraTF (cface_xy) => /eqP it_n. apply: (iter_looping (m := n.+1)).
+    + move => m Hm. apply: before_findex => //. exact: ltn_trans lt_n_y.
+    + by rewrite /looping it_n /= mem_head. }
+suff I : findex face' (Icp x) IcpXe = findex face x y.
+{ rewrite I.
+  apply: (@eq_from_nth _ (Icp x)); rewrite ?size_map !size_traject // => n Hn.
+  by rewrite nth_traject // (nth_map x) ?size_traject // nth_traject ?F. }
+have idx0 : 0 < findex face x y by rewrite lt0n findex_eq0.
+apply/eqP; rewrite eqn_leq; apply/andP; split.
+- apply: findex_bound. rewrite -(prednK idx0) iterS F ?prednK //.
+  rewrite -[iter _ _ _](finv_f faceI) -iterS prednK // iter_findex //=.
+  by rewrite !f_finv // eqxx eq_sym (negPf xDy).
+- rewrite leqNgt; apply/negP; set m := findex face' _ _ => /F.
+  by rewrite iter_findex // same_fconnect1_r //= connect0.
+Qed.
+
+(** The proof of this lemma is (essentially) the same as above plus
+some symmetry reasoning to swap [x] and [y]. *)
+Lemma add_edge_orbitX  : cface x y ->
+  orbit face (IcpX : H) = IcpX :: [seq Icp z | z <- arc (orbit face x) y x].
+Proof.
+set face' := add_edge_face; have faceI' : injective face' by apply: (@faceI H). 
+rewrite cfaceC => cface_xy.
+have -> : arc (orbit face x) y x = arc (orbit face y) y x.
+{ have/orbit_rot_cycle : x \in orbit face y by rewrite -fconnect_orbit.
+  move=> /(_ face); rewrite cycle_orbit // orbit_uniq => /(_ isT isT) [i ->].
+  by rewrite arc_rot // in_orbit. }
+rewrite arc_orbit // /orbit -orderSpred -findex_finv /=.
+congr (_ :: _); rewrite -findex_f ?fconnect_finv //= f_finv // -/face'.
+have F n :  n < findex face y x -> iter n face' (Icp y) = Icp (iter n face y).
+{ elim: n => // n IHn lt_n_y. 
+  rewrite iterS IHn 1?ltnW //= -iterS !ifF //; last first.
+  - by apply:negPf; apply: before_findex.
+  - apply: contraTF (cface_xy) => /eqP it_n. apply: (iter_looping (m := n.+1)).
+    + move => m Hm. apply: before_findex => //. exact: ltn_trans lt_n_y.
+    + by rewrite /looping it_n /= mem_head. }
+suff I : findex face' (Icp y) IcpX = findex face y x.
+{ rewrite I.
+  apply: (@eq_from_nth _ (Icp y)); rewrite ?size_map !size_traject // => n Hn.
+  by rewrite nth_traject // (nth_map y) ?size_traject // nth_traject ?F. }
+have idx0 : 0 < findex face y x by rewrite lt0n findex_eq0 eq_sym.
+apply/eqP; rewrite eqn_leq; apply/andP; split.
+- apply: findex_bound. rewrite -(prednK idx0) iterS F ?prednK //.
+  rewrite -[iter _ _ _](finv_f faceI) -iterS prednK // iter_findex //=.
+  by rewrite !f_finv // eqxx. 
+- rewrite leqNgt; apply/negP; set m := findex face' _ _ => /F.
+  by rewrite iter_findex // same_fconnect1_r //= connect0.
+Qed.
+
+Lemma add_edge_plain : plain G -> plain H.
+Proof.
+move=> plainG; apply/plainP => -[||z] _ //=.
+by rewrite (rwP eqP) !inj_eq // plain_eq // plain_neq.
+Qed.
+
+End AddEdge.
+
+(** The consruction [h_add_node G x] extends the hypermap [G] with an
+addional node on the inside of the face of [x] and connected only to
+[cnode x] *)
+
+Section AddNode.
+Variables (G : hypermap) (x : G).
+
+Definition add_node_edge (z : ecp_dart G) : ecp_dart G := 
+  match z with 
+  | IcpX => IcpXe
+  | IcpXe => IcpX
+  | Icp z => Icp (edge z)
+  end.
+
+Definition add_node_node (z : ecp_dart G) : ecp_dart G := 
+  match z with 
+  | IcpX => Icp (node x)
+  | IcpXe => IcpXe
+  | Icp z => if z == x then IcpX else Icp (node z) 
+  end.
+
+Definition add_node_face (z : ecp_dart G) : ecp_dart G := 
+  match z with 
+  | IcpX => IcpXe
+  | IcpXe => Icp x
+  | Icp z => if face z == x then IcpX else Icp (face z)
+  end.
+
+Lemma add_node_can3 : cancel3 add_node_edge add_node_node add_node_face.
+Proof.
+case => [||z]; rewrite /= ?eqxx //. 
+case: (eqVneq (face (edge z)) x) => /= [<-|Dx]; by rewrite ?(negbTE Dx) edgeK.
+Qed.
+
+Definition h_add_node := Hypermap add_node_can3.
+
+Let Ico_inj : injective (@Icp G). Proof. by move => u v []. Qed.
+
+Lemma add_node_plain : plain G -> plain h_add_node.
+Proof.
+move/plainP => plain_G; apply/plainP => -[||z] //= _.
+by move/(_ z isT) : plain_G => [-> ->].
+Qed.
+
+Lemma add_node_genus : genus h_add_node = genus G.
+Proof.
+set H := h_add_node.
+have SX : IcpX != IcpXe :> H by [].
+pose G' := @WalkupE (WalkupE (IcpXe : H)) (Sub IcpX SX).
+suff i : hiso G G'. 
+{ rewrite (hiso_genus i) !genus_WalkupE_eq //. 
+  - rewrite glinkN; tauto. 
+  - have E : Sub IcpX SX = @edge (WalkupE (IcpXe : H)) (Sub IcpX SX).
+      exact: val_inj.
+    by rewrite {2}E glinkE; tauto. }
+have S (z : G) : Icp z != IcpX by done. 
+pose i (z : G) : G' := Sub (Sub (Icp z) (S z)) SX.
+pose i_inv (z : G') : G := if val (val z) is Icp i then i else x.
+have vvE (z : G') : exists z', val (val z) = Icp z'. 
+{ move: z; (do 3 case) => //= a. by exists a. } 
+have can_fwd : cancel i_inv i. 
+{ move => u; case: (vvE u) => u' E; rewrite /i /i_inv E.
+  do 2 apply: val_inj => /=. by symmetry. }
+have can_bwd : cancel i i_inv by done. 
+have com_i_node u : i (node u) = node (i u).
+{ do 2 apply/val_inj; rewrite /= !fun_if /= -val_eqE /=.
+  by case: (eqVneq u x) => //= ->. }
+have com_i_edge u : i (edge u) = edge (i u). 
+{ do 2 apply: val_inj => //=; by case: (eqVneq (face (edge u)) x). }
+exact: (@Hiso _ _ (Bij can_bwd can_fwd) com_i_edge com_i_node).
+Qed.
+
+Lemma add_node_planar : planar h_add_node = planar G.
+Proof. by rewrite /planar add_node_genus. Qed.
+
+Lemma add_node_cfaceE u v : 
+  cface (Icp u : h_add_node) (Icp v) = cface u v.
+Proof.
+apply/idP/idP; case/connectP => p.
+- elim/(size_ind (@size h_add_node)) : p u => -[/= _ u _ [->] //|/= z p IH u].
+  have [fuEx /andP[/eqP <-] {z}|fuDx] := eqVneq (face u) x. 
+  + case: p IH => [|z p] //= IH => /andP[/eqP<-] {z}.
+    case: p IH => [|z p] //= IH => /andP[/eqP<-].
+    by rewrite cface1 fuEx; apply: IH; rewrite -addn2 leq_addr.
+  + case: z => [||z]; rewrite // inj_eq // => /andP [/eqP fu_z pth_p lst_p].
+    rewrite cface1 fu_z. exact: IH pth_p lst_p.
+- elim: p u => //= [u _ -> //|z p IHp u /andP[/eqP fu_z] pth_p lst_p].
+  have ? := @faceI h_add_node; rewrite same_fconnect1 //=.
+  have [fu_x|_] := eqVneq (face u) x; last by rewrite fu_z; exact: IHp.
+  rewrite same_fconnect1 //= same_fconnect1 //= -fu_x fu_z. exact: IHp.
+Qed.
+
+Lemma add_node_cnodeE u v : 
+  cnode (Icp u : h_add_node) (Icp v) = cnode u v.
+Proof.
+apply/idP/idP; case/connectP => p.
+- elim/(size_ind (@size h_add_node)) : p u => -[/= _ u _ [->] //|/= z p IH u].
+  have [fuEx /andP[/eqP <-] {z}|fuDx] := eqVneq u x. 
+  + case: p IH => [|z p] //= IH => /andP[/eqP<-] {z}. 
+    by rewrite cnode1 fuEx; apply: IH.
+  + case: z => [||z]; rewrite // inj_eq // => /andP [/eqP fu_z pth_p lst_p].
+    rewrite cnode1 fu_z. exact: IH pth_p lst_p.
+- elim: p u => //= [u _ -> //|z p IHp u /andP[/eqP fu_z] pth_p lst_p].
+  have ? := @nodeI h_add_node; rewrite same_fconnect1 //=.
+  have [fu_x|_] := eqVneq u x; last by rewrite fu_z; exact: IHp.
+  rewrite same_fconnect1 //= -fu_x fu_z. exact: IHp.
+Qed.
+
+Lemma add_node_cnodeXe u :  
+  cnode (IcpXe : h_add_node) u = (u == IcpXe).
+Proof.
+by apply/idP/eqP => [/connectP []|-> //]; elim => //= a p IH /andP[/eqP<-].
+Qed.
+
+Lemma add_node_adjn u v : 
+  adjn (Icp u : h_add_node) (Icp v) = adjn u v.
+Proof.
+apply/exists_inP/exists_inP => [|[z Z1 Z2]]; last by exists (Icp z); rewrite inE add_node_cnodeE.
+move=> [[||z] Z1 Z2]; rewrite !inE [edge _]/= in Z1 Z2. 
+- by rewrite cnodeC add_node_cnodeXe in Z2.
+- by rewrite cnodeC add_node_cnodeXe in Z1.
+- by exists z; rewrite inE -add_node_cnodeE.
+Qed.
+
+Lemma add_node_adjnXeXe : adjn (IcpXe : h_add_node) IcpXe = false.
+Proof.
+apply/negbTE/negP=>/exists_inP [z]; rewrite inE add_node_cnodeXe => /eqP->.
+by rewrite inE add_node_cnodeXe. 
+Qed.
+
+Lemma add_node_adjnXe u : adjn (IcpXe : h_add_node) (Icp u) = cnode x u.
+Proof.
+apply/exists_inP/idP => [[z]|x_u].
+  rewrite !inE add_node_cnodeXe cnodeC => /eqP->. 
+  by rewrite cnode1 add_node_cnodeE -cnode1.
+exists IcpXe; rewrite !inE // cnode1r [edge _]/=.
+by rewrite add_node_cnodeE -cnode1r cnodeC.
+Qed.
+
+Lemma add_node_face_orbitE : 
+  orbit add_node_face IcpX = [:: IcpX, IcpXe & [seq Icp z | z <- orbit face x]].
+Proof.
+rewrite /orbit. 
+have -> : order add_node_face IcpX = (arity x).+2. 
+{ rewrite /order -[in RHS](card_imset _ Ico_inj).
+  set IcpF := [set _ _ | _ in _].
+  rewrite [LHS](eq_card (_ : _ =i [set IcpX; IcpXe] :|: IcpF)).
+  - rewrite -setUA !cardsU1 !inE /= 2![_ \in IcpF](negbTE _) //.
+    all: by apply/negP => /imsetP [?].
+  - move => z; rewrite !inE. 
+    case: (eqVneq z IcpX) => [->|]; first by rewrite connect0.
+    case: (eqVneq z IcpXe) => [->|]; first by rewrite connect1.
+    have ? := @faceI h_add_node.
+    case: z => [z||]//= z _ _; rewrite same_fconnect1 //= same_fconnect1 //=.
+    rewrite /IcpF inj_imset // inE. exact: add_node_cfaceE. }
+rewrite /=; congr [:: _ , _ & _].
+apply: (@eq_from_nth _ (Icp x)); first by rewrite size_map !size_traject.
+move => n; rewrite size_traject => lt_n_st. 
+rewrite nth_traject // (nth_map x) ?size_traject // nth_traject //.
+elim: n lt_n_st => // n IHn lt_Sn_x. rewrite iterS IHn 1?ltnW //= -iterS ifF //.
+apply: contraTF (lt_Sn_x) => /eqP; rewrite -leqNgt => fix_x.
+exact: order_le_fix.
+Qed.
+
+End AddNode.

--- a/theories/wagner.v
+++ b/theories/wagner.v
@@ -387,7 +387,7 @@ have [] := @plane_add_node' _ g2 x2 x1 s2 [set z in X] => //.
       by rewrite inG2E. }
     have dhom_fwd : is_dhom fwd. 
     { move => [[u|]|] [[v|]|] //=.
-      - move => uv. by rewrite (@smerge2_val_edge _ x y) ?induced_val_edge //; exact: G2Dx.
+      - move => uv. by rewrite (@smerge2_val_edge _ x y) ?induced_edge //; exact: G2Dx.
       - by rewrite {1}/edge_rel/={1}/edge_rel/= inE mem_filter sgP => /andP[-> _].
       - by rewrite {1}/edge_rel/= !(inE, inj_imset) // orFb mem_filter sgP => /andP[-> _].
       - by rewrite {1}/edge_rel/={1}/edge_rel/= inE mem_filter => /andP[-> _].
@@ -414,7 +414,7 @@ have [] := @plane_add_node' _ g2 x2 x1 s2 [set z in X] => //.
       have [?|vDx] := eqVneq v x; first subst v.
         by rewrite /edge_rel/= /edge_rel/= inE inG2X.
       rewrite /edge_rel /= /edge_rel/= /edge_rel/=. 
-      rewrite induced_val_edge. rewrite /edge_rel/= !inG2E /=.
+      rewrite -induced_edge /edge_rel/= !inG2E /=.
       by rewrite -(@smerge2_val_edge _ x y). }
     exact: (@Diso _ _ (Bij can_fwd can_bwd) dhom_fwd dhom_bwd).
 Qed.

--- a/theories/wagner.v
+++ b/theories/wagner.v
@@ -1,0 +1,654 @@
+From mathcomp Require Import all_ssreflect.
+Require Import edone preliminaries bij digraph sgraph connectivity minor excluded.
+From fourcolor Require Import hypermap geometry walkup color coloring combinatorial4ct.
+Require Import set_tac.
+
+Require Import hmap_ops smerge embedding arc K4plane.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Set Bullet Behavior "Strict Subproofs".
+
+(** These depend on [arc.v] which is pure mathcomp *)
+
+Lemma connected_path0 (G : sgraph) (p : seq G) : 
+  path0 (--) p -> sgraph.connected [set z in p].
+Proof.
+case: p => [|x p] => [_|/= pth_p]; first exact: connected0.
+have -> : x::p = nodes (Path_of_path pth_p) by rewrite nodesE.
+exact: connected_path.
+Qed.
+
+Lemma connected_arc (G : sgraph) (s : seq G) x1 x2 :
+  ucycle (--) s -> x1 \in s -> x2 \in s -> x1 != x2 -> sgraph.connected [set z in arc s x1 x2].
+Proof. by move=> *; exact/connected_path0/arc_path. Qed.
+
+(** * Wagners Theorem (Main Direction) *)
+
+(** This file contains the main argument for Wagner's theorem and, as a corollary, the four-colorability of ['K_5]-and ['K_3,3]-free graphs. However, the proof depends heavily on numberous other libraries:
+
+- smerge: the operation of merging two vertices [x] and [y] in a simple graph (i.e., edge contraction if [x -- y]). This includes the proof that every 3-connected graph with at least 5 vertices has an edge whose contraction preserves 3-connectedness.
+- embedding: the definition of plane embeddings using planar hypermaps and various constructions on plane embeddings, (e.g., deleting a vertex and obtaining its surrounding face or splitting a face by adding an edge).
+- switch: various constructions on hypermaps underlying the constructions on plane embeddings and the proofs that they preserve planarity and have the desired properties (e.g., the right faces).
+- K4plane: The plane embedding for ['K_4], providing the base case for Wagner's theorem.
+- arc: various properties of the [arc] function (i.e., the one that selects arcs from cycles) that were needed and could be added to mathcomp.
+- hycle: a proof that in a 2-connected (in the graph sense) hypermap, all the darts of every face cycle belong to different node cycles. This makes use of the Jordan curve theorem for hypermaps.
+
+Further, we use some preexisting libraries
+- sgraph: simple graphs and their isomporphisms
+- minor: the definition of graph minors and various of their properties.
+- connectivity: separators and separations. *)
+
+(** ** Preliminaries *)
+
+
+Definition kplanar G := ~ minor G ('K_3,3) /\ ~ minor G 'K_5.
+
+Definition kplanar_minor G G' : minor G G' -> kplanar G -> kplanar G'.
+Proof. 
+move => G_G' [K1 K2]. 
+split; [apply: contra_not K1|apply: contra_not K2]; exact: minor_trans G_G'.
+Qed.
+
+(** [prev] also refers to path reversal for packaged paths, which we don't use here *)
+Local Notation prev := path.prev.
+Local Notation mem_prev := path.mem_prev.
+
+(** ** The 3-connected Case *)
+
+(** Lemma 12 *)
+Lemma wagner_no_cross (G : sgraph) (x y : G) (s : seq G) : 
+  kplanar G -> ucycle (--) s ->
+  x -- y -> x \notin s -> y \notin s ->
+  let X := [seq z <- s | x -- z] in
+  let Y := [seq z <- s | y -- z] in
+  2 <= #|X| -> 2 <= #|Y| -> 
+  exists2 z, z \in X & {subset Y <= rcons (arc s z (next X z)) (next X z) }. 
+Proof.
+move => [K33_free K5_free] ucycle_s xy xNs yNs X Y Xgt1 Ygt1.
+have uniq_s := ucycle_uniq ucycle_s.
+pose XY := [set z in X | z \in Y].
+have sub_s : {subset XY <= s}. 
+{ by move => z; rewrite !inE !mem_filter -!andbA=> /and3P [_ -> _]. }
+have [X_sub_s Y_sub_s] : {subset X <= s} /\ {subset Y <= s}.
+{ by split => u; rewrite mem_filter => /andP [_ ->]. }
+have maxXY : #|XY| <= 2.
+{ apply: contra_notT K5_free; rewrite leqNgt negbK => card_XY.
+  (* TODO: simplify *)
+  have [p []]:= subseq_of_subset (uniq_s) sub_s card_XY.
+  move: p => [//|u1 [//|u2 [//|u3 [|//]]]] => P1 _ P2. 
+  set u := _ :: _ in P1 P2.
+  have: uniq u by apply: subseq_uniq P2 _. 
+  rewrite /= !inE negb_or andbT -andbA [u1 == u3]eq_sym => /and3P [U1 U3 U2]. 
+  have [N1 N2 N3] : [/\ next u u1 = u2, next u u2 = u3 & next u u3 = u1].
+    by rewrite /= !eqxx !ifN // eq_sym. 
+  pose phi (i : 'K_5) : {set G} := 
+      match i with
+      | Ordinal 0 _ => [set x]
+      | Ordinal 1 _ => [set y]
+      | Ordinal 2 _ => [set z in arc s u1 u2]
+      | Ordinal 3 _ => [set z in arc s u2 u3]
+      | Ordinal 4 _ => [set z in arc s u3 u1]
+      | _ => set0
+      end.
+  apply: (@minor_of_rmap _ _ phi).
+  have head_s := head_arc _ uniq_s.
+  have [? ? ?] : [/\ u1 \in s, u2 \in s & u3 \in s].
+  { by split;apply: (mem_subseq P2); rewrite !inE eqxx. }
+  apply: ordered_rmap; first apply: ord_inj; split.
+  - case;case => [|[|[|[|[|//]]]]] /= _; try exact: set10.
+    all: match goal with |- is_true ([set _ in arc _ ?u1 _] != set0) => 
+         by apply/set0Pn; exists u1; rewrite inE head_s end.
+  - case;case => [|[|[|[|[|//]]]]] /= _; try exact: connected1.
+    all: apply: connected_arc => //.
+    all: by apply: (mem_subseq P2); rewrite !inE eqxx.
+  - case;case => [|[|[|[|[|//]]]]] /= i; case;case => [|[|[|[|[|//]]]]] //= {i} _ _ _.
+    1-7: rewrite disjoints1 ?in_set1 ?sg_edgeNeq //.
+    1-3: by apply: contraNN xNs; rewrite inE; exact: mem_arc.
+    1-3: by apply: contraNN yNs; rewrite inE; exact: mem_arc.
+    all: repeat under eq_disjoint => z do rewrite inE //. 
+    all: repeat under eq_disjoint_r => z do rewrite inE //. 
+    1: rewrite -{1}N1 -{1}N2. 
+    2: rewrite -{1}N1 -{3}N3.
+    3: rewrite -{1}N2 -{1}N3.
+    all: by apply: (arc_next_disjoint uniq_s) => //; rewrite 1?eq_sym // !inE eqxx.
+  - have E z : z \in u -> (x -- z)*(y -- z). 
+    { by move/P1;rewrite !inE !mem_filter => -/andP[/andP[? ?] /andP[? ?]]; split. }
+    case;case => [|[|[|[|[|//]]]]] /= i; case;case => [|[|[|[|[|//]]]]] //= {i} _ _ _.
+    1-7: apply/neighbor1P. 8-10: apply/neighborP.
+    + by exists y; rewrite ?inE.
+    + exists u1. by rewrite E ?inE ?eqxx. by rewrite inE head_s.
+    + exists u2. by rewrite E ?inE ?eqxx. by rewrite inE head_s.
+    + exists u3. by rewrite E ?inE ?eqxx. by rewrite inE head_s.
+    + exists u1. by rewrite E ?inE ?eqxx. by rewrite inE head_s.
+    + exists u2. by rewrite E ?inE ?eqxx. by rewrite inE head_s.
+    + exists u3. by rewrite E ?inE ?eqxx. by rewrite inE head_s.
+    + exists (last u1 (arc s u1 u2)), u2. by rewrite !inE last_mem head_s // arc_edge.
+    + exists u1,(last u3 (arc s u3 u1)). by rewrite !inE last_mem head_s // sgP arc_edge.
+    + exists (last u2 (arc s u2 u3)), u3. by rewrite !inE last_mem head_s // arc_edge. }
+have no_cross : ~ exists x1 x2 y1 y2, [/\ x1 \in X, x2 \in X, y1 \in Y , y2 \in Y & subcycle [:: x1; y1; x2; y2] s].
+{ apply: contra_not K33_free => -[x1] [x2] [y1] [y2] [x1X x2X y1Y y2Y sub]. 
+  pose u := [:: x1; y1; x2; y2].
+  pose phi (i : 'K_3,3) : {set G} := 
+    match i with 
+    | inl (Ordinal 0 _) => [set x]
+    | inr (Ordinal 0 _) => [set y]
+    | inl (Ordinal 1 _) => [set z in arc s y1 x2]
+    | inl (Ordinal 2 _) => [set z in arc s y2 x1]
+    | inr (Ordinal 1 _) => [set z in arc s x1 y1]
+    | inr (Ordinal 2 _) => [set z in arc s x2 y2]
+    |  _ => set0 
+    end.
+  suff: minor_rmap phi by apply minor_of_rmap.
+  have head_s := head_arc _ uniq_s.
+  have xz z : z \in X -> x -- z by rewrite !mem_filter => /andP[-> _].
+  have yz z : z \in Y -> y -- z by rewrite !mem_filter => /andP[-> _].
+  have : uniq u. apply: subcycle_uniq sub _. apply: ucycle_uniq ucycle_s.
+  rewrite /u /= !inE !negb_or -!andbA andbT => /and5P[? ? ? ? /andP [? ?]].
+  have u_sub_s := mem_subcycle sub.
+  apply: ordered_rmap; first exact: pickle_Knn_inj; split.
+  - case; case; case => [|[|[|//]]] /= _; try exact: set10.
+    all: match goal with |- is_true ([set _ in arc _ ?u1 _] != set0) => 
+         apply/set0Pn; exists u1; rewrite inE head_s // 1?eq_sym // end.
+    all: by apply: u_sub_s; rewrite !inE eqxx.
+  - case; case; case => [|[|[|//]]] /= _; try exact: connected1.
+    all: apply: connected_arc; rewrite // 1?eq_sym //.
+    all: by apply: u_sub_s; rewrite !inE eqxx.
+  - case; case; case => [|[|[|//]]] /= i; case; case; case => [|[|[|//]]] //= {i} _ _ _.
+    all: rewrite ?disjoints1 ?[[disjoint _ & [set _]]]disjoint_sym ?disjoints1 ?inE.
+    3: by rewrite sg_edgeNeq.
+    all: try solve [apply: contraNN xNs; apply: mem_arc].
+    all: try solve [apply: contraNN yNs; apply: mem_arc].
+    all: apply: (arc_subcycle_disjoints uniq_s sub). 
+    all: by rewrite ?inE /= ?eqxx // ?ifN // 1?eq_sym.    
+  - case; case; case => [|[|[|//]]] /= i; case; case; case => [|[|[|//]]] //= {i} _ _ _.
+    4,7 : rewrite neighborC.
+    1-5 : apply/neighbor1P. 
+    6-9: apply/neighborP.
+    + by exists y; rewrite ?inE.
+    + by exists x1; rewrite ?xz // inE head_s // 1?eq_sym // u_sub_s ?inE ?eqxx. 
+    + by exists x2; rewrite ?xz // inE head_s // 1?eq_sym // u_sub_s ?inE ?eqxx.
+    + by exists y1; rewrite ?yz // inE head_s // 1?eq_sym // u_sub_s ?inE ?eqxx.
+    + by exists y2; rewrite ?yz // inE head_s // 1?eq_sym // u_sub_s ?inE ?eqxx.
+    + exists y1, (last x1 (arc s x1 y1)). 
+      by rewrite sgP !inE last_mem head_s ?arc_edge // u_sub_s ?inE ?eqxx.
+    + exists (last y1 (arc s y1 x2)), x2. 
+      by rewrite !inE last_mem head_s ?arc_edge // u_sub_s ?inE ?eqxx.
+    + exists (last y2 (arc s y2 x1)), x1.
+      by rewrite !inE last_mem head_s ?arc_edge // 1?eq_sym // u_sub_s ?inE ?eqxx.
+    + exists y2, (last x2 (arc s x2 y2)). 
+      by rewrite sgP !inE last_mem head_s ?arc_edge // 1?eq_sym // u_sub_s ?inE ?eqxx. }
+suff: ~ forall x, x \in X -> exists2 y, y \in Y & y \notin rcons (arc s x (next X x)) (next X x).
+{ move => NC; apply/exists_inPP => [u|]; first exact/allP. 
+  apply: contra_notT NC => /exists_inPn H u u_X.
+  have [v v_Y ?] := allPn (H _ u_X); by exists v. }
+apply: contra_not no_cross => not_contained.
+have [uniq_X uniq_Y] : uniq X /\ uniq Y by rewrite filter_uniq // filter_uniq.
+have subcycle_X : subcycle X s by rewrite subseq_subcyle // filter_subseq.
+have size_X : 2 <= size X by rewrite -(card_uniqP _).
+have [/allP Y_sub_X |/allPn [y1 y1_Y y1NX]] := (boolP (all (fun z => z \in X) Y)).
+- (* case where [Y \subset X] *)
+  have [y1 [y2 [defY y1Dy2]]]: exists y1 y2, Y = [:: y1; y2] /\ y1 != y2.
+  { suff: size Y == 2.
+      by move: uniq_Y; destruct Y as [|y1 [|y2 [|]]]; rewrite //= inE andbT; exists y1,y2.
+   rewrite eqn_leq -(card_uniqP _) // Ygt1 andbT.
+   apply: leq_trans maxXY. apply: subset_leq_card. 
+   apply/subsetP => y1 inY. by rewrite inE Y_sub_X inY . }
+  have {defY} eqY : Y =i [set y1;y2] by move=>?; rewrite defY !inE.
+  have xDy xi yi : xi \notin Y -> yi \in Y -> xi == yi = false.
+    by move=> xiNY; apply: contraTF => /eqP<-.
+  gen have H,Py1 : y1 y2 eqY y1Dy2 / prev X y1 \notin Y. 
+  { have ? : y1 \in X by rewrite Y_sub_X // eqY !inE eqxx.
+    apply/negP => py_Y. 
+    have E : prev X y1 = y2.
+      by apply: contraTeq py_Y => C; rewrite eqY !inE negb_or C eq_sym prev_neq.
+    move/Y_sub_X : (py_Y) => /not_contained [z z_Y]. 
+    rewrite mem_rcons inE E negb_or => /andP[zDny2]. 
+    move: z_Y; rewrite eqY => /set2P [z_y1|->]. 
+    - by subst z; rewrite -E next_prev ?eqxx in zDny2. 
+    - by rewrite head_arc // ?next_neq // ?X_sub_s // ?mem_next Y_sub_X // eqY !inE eqxx. }
+  have := H y2 y1; rewrite setUC eq_sym => /(_ eqY y1Dy2) => {H} Py2.
+  have [y1_X y1_Y y2_X y2_Y] : [/\ y1 \in X, y1 \in Y, y2 \in X & y2 \in Y]. 
+    by rewrite !Y_sub_X !eqY !inE !eqxx.
+  pose x1 := prev X y1; pose x2 := prev X y2. rewrite -/x1 -/x2 in Py1 Py2.
+  exists x1, x2, y1, y2; rewrite !path.mem_prev; split => //. 
+  apply: subcycle_trans subcycle_X. 
+  have x1Dx2 : x1 != x2. 
+  { apply:contra_neq y1Dy2 => eq_x.
+    by rewrite -[y1](next_prev uniq_X) -/x1 eq_x next_prev. }
+  have [x1_X x2_X] : x1 \in X /\ x2 \in X by rewrite !path.mem_prev !Y_sub_X.
+  have [i X1 X2 arc1 arc2 rot_i] := rot_to_arc uniq_X x1_X x2_X x1Dx2.
+  rewrite -(subcycle_rot_r i) rot_i; apply: subseq_subcyle. 
+  rewrite /= eqxx -cat1s; apply: cat_subseq; rewrite /= ?eqxx sub1seq.
+  + have := next_mem_arc uniq_X x1_X x2_X x1Dx2. 
+    by rewrite next_prev // mem_rcons -arc1 !inE ![y1 == _]eq_sym !xDy.
+  + rewrite eq_sym in x1Dx2; have := next_mem_arc uniq_X x2_X x1_X x1Dx2. 
+    by rewrite next_prev // mem_rcons -arc2 !inE ![y2 == _]eq_sym !xDy. 
+- (* case where [y1 \in Y :\: X] *)
+  have y1_s : y1 \in s by move: y1_Y; rewrite mem_filter => /andP[_ ->].
+  have [x1 x1_X x1_y1] := subcycle_get_arc y1_s uniq_s subcycle_X size_X.
+  have [y2 y2_Y foo] := not_contained _ x1_X.
+  set x2 := next X x1 in x1_y1 foo. 
+  exists x1,x2,y1,y2. rewrite !mem_next; split => //.
+  have [x1_s x2_s] : x1 \in s /\ x2 \in s by rewrite !X_sub_s // mem_next.
+  have x1Dx2 : x1 != x2 by exact: next_neq.
+  have [i s1 s2 def_s1 def_s2 rot_s] := rot_to_arc uniq_s x1_s x2_s x1Dx2.
+  rewrite -(subcycle_rot_r i) rot_s subseq_subcyle //= eqxx -cat1s.
+  apply: cat_subseq; rewrite /= ?eqxx sub1seq.
+  + move: x1_y1. rewrite -def_s1 inE [_ == _](_ : _ = false) //.
+    by apply: contraNF y1NX => /eqP ->.
+  + have:= Y_sub_s _ y2_Y; rewrite -(mem_rot i) rot_s -cat_cons -[x2 :: _]cat1s.
+    by rewrite catA cats1 def_s1 mem_cat (negbTE foo).
+Qed.
+
+(** Proposition 7 *)
+Proposition wagner3 (G : sgraph) : 
+  3.-connected G -> kplanar G -> inhabited (plane_embedding G).
+Proof.
+elim/card_ind : G => G IH conn_G kplanar_G. 
+have [le_5_G|le_G_4] := (ltnP 4 #|G|); last first. 
+{ suff i : diso 'K_4 G. 
+    by exists; apply: diso_plane_embedding i; apply: K4_plane_emb.
+  have/eqP -> : 4 == #|G| by rewrite eqn_leq le_G_4 (proj1 conn_G).
+  by apply/diso_sym/diso_Kn; apply: kconnected_complete le_G_4. }
+have [x [y [xy conn_G1]]] := contract_three_connected le_5_G conn_G.
+set G1 := smerge2 G x y in conn_G1.
+have kplanar_G1 := kplanar_minor (smerge2_minor xy) kplanar_G.
+have [|g1] := IH G1 _ conn_G1 kplanar_G1.
+  by rewrite card_sig [X in _ < X](@cardD1x _ _ y).
+wlog simple_g1 : g1 / simple_hmap (emb_map g1).
+{ move => W; have [g1'] := simple_embedding g1; exact: W. }
+have xDy : x != y by rewrite (sg_edgeNeq xy).
+pose v_xy : G1 := Sub x xDy.
+pose G2 := induced [set~ v_xy].
+have conn_G2 : 2.-connected G2 by apply/konnected_del1.
+have G2Dx (u : G2) : val2 u != x. 
+{ by apply: contraTneq (valP u); rewrite !inE negbK -val_eqE -/(val2 _) => ->. }
+have conn2_G1 : 2.-connected G1 by apply: (@kconnectedW 1); rewrite addn1.
+pose g2 := @del_vertex_plane_embedding _ g1 v_xy conn2_G1 simple_g1.
+have := @del_vertex_neighbor_face G1 g1 v_xy conn2_G1 simple_g1.
+rewrite -/G2 -/g2; case => [s2 face_s2 neighb_s2]. 
+pose X : seq G2 := [seq z <- s2 | x -- val2 z].
+pose Y : seq G2 := [seq z <- s2 | y -- val2 z].
+have uniq_s2 : uniq s2 by apply:face_uniq face_s2.
+have uniq_X : uniq X by apply: filter_uniq.
+have uniq_Y : uniq Y by apply: filter_uniq.
+have degG (z : G) : 3 <= #|N(z)| by apply: kconnected_degree.
+have inG2P u (uDx : u != x) (uDy : u != y) : Sub u uDy \in [set~ v_xy].
+  by rewrite !inE -val_eqE.
+have eq_X : val2 @: X =i N(x) :\ y.
+{ move=> z; rewrite !inE. apply/imsetP/andP => [[z0 z0X -> {z}]|[zDy xz]].
+    move: z0X; rewrite mem_filter => /andP[-> _]; by rewrite (valP (val z0)).
+  have zDx : z != x by apply: contraTneq xz => ->; rewrite sgP.
+  exists (Sub (Sub z zDy) (inG2P _ zDx zDy)) => //. 
+  rewrite /X mem_filter /= xz /= -(@mem_map G2 G1 val) //=.
+  by apply: neighb_s2; rewrite /= inE /edge_rel/= eqxx zDx sg_sym xz. }
+have sizeX : 1 < size X. 
+{ rewrite -(card_uniqP _) // -!(card_imset _ val_inj) -imset_comp.
+  rewrite (eq_card eq_X). apply: leq_trans (leq_cardsD1 _ _). 
+  rewrite -ltnS; apply: leq_trans (degG x) _. exact: leqSpred. }
+have eq_Y : val2 @: Y =i N(y) :\ x.
+{ move=> z; rewrite !inE. apply/imsetP/andP => [[z0 z0X -> {z}]|[zDx yz]].
+    by move: z0X; rewrite mem_filter => /andP[-> _].
+ have zDy : z != y by apply: contraTneq yz => ->; rewrite sgP.
+ exists (Sub (Sub z zDy) (inG2P _ zDx zDy)) => //. 
+ rewrite /Y mem_filter /= yz -(@mem_map G2 G1 val) //.
+ by apply: neighb_s2; rewrite /= inE /edge_rel/= eqxx zDx [z -- y]sgP yz orbT. }
+have sizeY : 1 < size Y. 
+{ rewrite -(card_uniqP _) //; rewrite -!(card_imset _ val_inj) -imset_comp.
+  rewrite (eq_card eq_Y). apply: leq_trans (leq_cardsD1 _ _). 
+  rewrite -ltnS; apply: leq_trans (degG y) _. exact: leqSpred. }
+(* in particular, we can now get a default vertex in G2 for free *)
+have v2 : G2 by move: sizeX; destruct X. 
+pose inG2 (u : G) : G2 := insubd v2 (insubd v_xy u).
+have inG2E u (uDx : u != x) (uDy : u != y) : inG2 u = Sub (Sub u uDy) (inG2P _ uDx uDy) :> G2.
+{ rewrite /inG2 !insubdT ?inG2P // => p. exact: val_inj. }
+have inG2K (u : G2) : inG2 (val (val u)) = u. 
+{ rewrite inG2E ?(valP (val u)) // ?G2Dx // => p q. by do 2 apply: val_inj. }
+(* Prove that Y2 is contained in of of the arcs spanned by X1 *)
+have [x1 x1_X Y_segment] : exists2 x1, 
+  x1 \in X & {subset Y <= rcons (arc s2 x1 (next X x1)) (next X x1) }. 
+{ pose s := [seq val x | x <- [seq val x | x <- s2]].
+  have uniq_s : uniq s by rewrite !map_inj_uniq //; exact: val_inj.
+  have xNs : x \notin s. 
+   by apply/negP => /mapP [? /mapP [x0] _ ->] /eqP; apply/negP; rewrite eq_sym G2Dx.
+  have yNs : y \notin s. 
+  { apply/negP => /mapP [? /mapP [y0 _ ->]] /eqP. 
+    by apply/negP; rewrite eq_sym (valP (val y0)). }
+  have ucycle_s : ucycle (--) s. 
+  { apply: smerge2_ucycle xNs. 
+    rewrite -ucycle_induced /ucycle uniq_s2 andbT. exact: sface_cyle face_s2. }
+  pose X' := [seq z <- s | x -- z]. 
+  pose Y' := [seq z <- s | y -- z].
+  have size_X' : 2 <= #|X'|. 
+  { suff -> : X' = map val (map val X). 
+      by rewrite (card_uniqP _) ?map_inj_uniq // !size_map.
+    by rewrite /X'/s/X !filter_map. }
+  have size_y' : 2 <= #|Y'|. 
+  { suff -> : Y' = map val (map val Y). 
+      by rewrite (card_uniqP _) ?map_inj_uniq // !size_map.
+    by rewrite /Y'/s/Y !filter_map. }
+  (* Central Lemma on excluded minors *)
+  have [z Z1 Z2] := wagner_no_cross kplanar_G ucycle_s xy xNs yNs size_X' size_y'.
+  rewrite -/X' -/Y' in Z2.
+  move: Z1; rewrite mem_filter => /andP [xz z_s].
+  have zDy : z != y by apply: contraTneq z_s => ->.
+  have zDv : (Sub z zDy : G1) \in [set~ v_xy] by rewrite !inE -val_eqE /= eq_sym sg_edgeNeq.
+  pose x1 := Sub (Sub z zDy) zDv : G2.
+  exists x1. 
+  - rewrite mem_filter /= xz //=. 
+    by move: z_s; rewrite -[z]/(val (val x1)) !mem_map. 
+  - move => u u_Y. 
+    rewrite -(@mem_map _ _ val2); last exact: val2_inj.
+    rewrite map_rcons map_arc 1?map_comp -/s -!/(val2 _); last exact: val2_inj. 
+    rewrite -next_map; last exact: val2_inj. 
+    have -> : map val2 X = X' by rewrite /X' /s !filter_map /= -map_comp.
+    apply: Z2. move: u_Y. rewrite !mem_filter => /andP[->] /=.
+    by rewrite /s !mem_map. }
+set x2 := next X x1 in Y_segment.
+have x2_X : x2 \in X by rewrite mem_next.
+have x1Dx2 : x1 != x2 by apply next_neq.
+(* Reconstruct [G] (up to iso) from [G2] by first adding back [x] and
+then adding back [y], while showing that this preserves the planarity
+(of G2) *)
+have [x1_s1 x2_s2] : x1 \in s2 /\ x2 \in s2. 
+  split; [exact: sub_filter x1_X|exact: sub_filter x2_X].
+have [] := @plane_add_node' _ g2 x2 x1 s2 [set z in X] => //.
+- by rewrite eq_sym.
+- by move=> z; rewrite inE; apply: arc_remainder => //; exact: filter_subseq.
+- by rewrite inE. 
+- by rewrite inE. 
+- move => g' face_g'.
+  set G' := add_node G2 _ in g' face_g'.
+  set s2' := (Some _ :: _ : seq G') in face_g'.
+  pose Y' : {set G'} := None |: Some @: [set z in Y].
+  have [||g''] := @plane_add_node_simple G' g' _ Y' None _ face_g'.
+  + by rewrite in_setU1 eqxx.
+  + move=>z; rewrite !inE => /predU1P [->|/imsetP [z0]]; first by rewrite eqxx.
+    rewrite !inE => /Y_segment.
+    rewrite mem_rcons inE => /predU1P [-> -> //|z_arc ->]; first by rewrite eqxx.
+    rewrite mem_map ?z_arc //; exact: Some_inj.
+  + suff i: diso (add_node G' Y') G by exists; apply: diso_plane_embedding g'' i.
+    set G'' := add_node _ _.
+    pose fwd (x0 : G'') : G := 
+      if x0 isn't Some z0 then y else
+      if z0 isn't Some z then x else val2 z.
+    pose bwd (x0 : G) : G'' := 
+      if x0 == y then None else 
+      if x0 == x then Some None else Some (Some (inG2 x0)).
+    have can_fwd : cancel fwd bwd.
+    { move => [[x0|]|]; rewrite /bwd ?eqxx ?(negPf xDy) //.
+      by rewrite (negbTE (valP (val x0))) (negbTE (G2Dx x0)) inG2K. }
+    have can_bwd : cancel bwd fwd. 
+    { move=> u. rewrite /fwd/bwd. 
+      have [-> //|yDu] := eqVneq u y; have [-> //|xDu] := eqVneq u x.
+      by rewrite inG2E. }
+    have dhom_fwd : is_dhom fwd. 
+    { move => [[u|]|] [[v|]|] //=.
+      - move => uv. by rewrite (@smerge2_val_edge _ x y) ?induced_val_edge //; exact: G2Dx.
+      - by rewrite {1}/edge_rel/={1}/edge_rel/= inE mem_filter sgP => /andP[-> _].
+      - by rewrite {1}/edge_rel/= !(inE, inj_imset) // orFb mem_filter sgP => /andP[-> _].
+      - by rewrite {1}/edge_rel/={1}/edge_rel/= inE mem_filter => /andP[-> _].
+      - by rewrite {1}/edge_rel/= !(inE, inj_imset) // orFb mem_filter => /andP[-> _].
+      - by rewrite [y -- x]sgP. }
+    have inG2Y u : u != x -> u != y -> u -- y -> inG2 u \in Y.
+    { move=> uDx uDy uy. rewrite inG2E -!(@inj_imset _ _ val) // -imset_comp eq_Y /=.
+      by rewrite !inE uDx sgP. }
+    have inG2X u : u != x -> u != y -> u -- x -> inG2 u \in X.
+    { move=> uDx uDy uy. rewrite inG2E -!(@inj_imset _ _ val) // -imset_comp eq_X /=.
+      by rewrite !inE uDy sgP. }
+    have dhom_bwd : is_dhom bwd. 
+    { move => u v uv; rewrite /bwd. 
+      have [?|uDy] := eqVneq u y; first subst u. 
+        have [E|vDy] := eqVneq v y; first by rewrite E sgP in uv.
+        have [?|vDx] := eqVneq v x; first by rewrite /edge_rel/= !inE eqxx.
+        by rewrite /edge_rel/= inE inj_imset // inE inG2Y 1?sgP.
+      have [?|uDx] := eqVneq u x;first subst u. 
+        have [E|vDx] := eqVneq v x; first by rewrite E sgP in uv.
+        have [?|vDy] := eqVneq v y; first by rewrite /edge_rel/= !inE eqxx.
+        by rewrite /edge_rel/= /edge_rel/= inE inG2X 1?sgP.
+      have [?|vDy] := eqVneq v y; first subst v. 
+        by rewrite /edge_rel/= inE inj_imset // inE inG2Y.
+      have [?|vDx] := eqVneq v x; first subst v.
+        by rewrite /edge_rel/= /edge_rel/= inE inG2X.
+      rewrite /edge_rel /= /edge_rel/= /edge_rel/=. 
+      rewrite induced_val_edge. rewrite /edge_rel/= !inG2E /=.
+      by rewrite -(@smerge2_val_edge _ x y). }
+    exact: (@Diso _ _ (Bij can_fwd can_bwd) dhom_fwd dhom_bwd).
+Qed.
+
+
+
+
+(** ** The General Case *)
+
+
+Lemma vertex_plane_embedding (G : sgraph) (V1 V2 : {set G}) (x : G) :
+  V1 :&: V2 = [set x] -> separation V1 V2 ->
+  plane_embedding (induced V1) -> plane_embedding (induced V2) ->
+  inhabited (plane_embedding G).
+Proof.
+move => capV sepV g1 g2.
+have [xV1 xV2] : x \in V1 /\ x \in V2 by split; set_tac.
+pose G1 := induced V1; pose G2 := induced V2.
+have : diso (smerge2 (G1 ∔ G2) (inl (Sub x xV1)) (inr (Sub x xV2))) G.
+  exact: diso_separation1.
+apply: diso_plane_embedding_inh. 
+apply: smerge_plane_embedding_disconnected.
+  by apply: union_plane_embedding.
+exact: sjoin_disconnected.
+Qed.
+
+(** Lemma 31 *)
+Lemma edge_plane_embedding (G : sgraph) (V1 V2 : {set G}) (x y : G) :
+  x -- y -> V1 :&: V2 = [set x; y] -> separation V1 V2 ->
+  plane_embedding (induced V1) -> plane_embedding (induced V2) ->
+  inhabited (plane_embedding G).
+Proof.
+move => xy capV sepV.
+have [xV1 xV2 yV1 yV2] : [/\ x \in V1, x \in V2, y \in V1 & y \in V2].
+  by split; set_tac.
+have xDy : x != y by rewrite (sg_edgeNeq xy).
+set G1 := induced V1; set G2 := induced V2; move => g1 g2.
+set G12 := (G1 ∔ G2)%sg.
+have g12 := union_plane_embedding g1 g2.
+pose x1 : G12 := inl (Sub x xV1); pose x2 : G12 := inr (Sub x xV2).
+pose y1 : G12 := inl (Sub y yV1); pose y2 : G12 := inr (Sub y yV2).
+have xy1 : x1 -- y1 by [].
+have yx2 : y2 -- x2 by rewrite sgP.
+have nc_x1_x2 : ~~ connect (--) x1 x2 by rewrite sjoin_disconnected.
+have [xs face_xs] := plane_emb_face g12 xy1.
+have [ys face_ys] : exists ys, sface g12 (x2 :: rcons ys y2).
+{ have [ys face_ys] := plane_emb_face g12 yx2. 
+  by exists ys; move/(rot_face 1) : face_ys; rewrite rot1_cons. } 
+pose Gm := smerge2 G12 x1 x2.
+have := smerge_plane_embedding_disconnected' nc_x1_x2 face_xs face_ys.
+rewrite -/Gm => -[g' [s' [face_s' eq_val_s]]].
+have y1Gm : y1 != x2 by [].
+have y2Gm : y2 != x2 :> G12 by rewrite (inj_eq inr_inj) eq_sym -val_eqE.
+pose y1' : Gm := Sub y1 y1Gm.
+pose y2' : Gm := Sub y2 y2Gm.
+pose Gm' := smerge2 Gm y1' y2'.
+have [y1s' y2s'] : y1' \in s' /\ y2' \in s'. 
+{ by rewrite -!(mem_map val_inj) !eq_val_s // !(inE,mem_cat,mem_rcons) /= !eqxx. }
+have y1Dy2' : y1' != y2' by rewrite -val_eqE. 
+have y1Ny2' : ~~ y1' -- y2'. 
+{ by rewrite /edge_rel/= eq_sym (inj_eq inl_inj) -val_eqE /= (negbTE xDy). }
+have : diso Gm' G by exact: diso_separation2.
+apply: diso_plane_embedding_inh.
+exact: smerge_plane_embedding_face face_s'.
+Qed.
+
+Lemma kplanar_add_edge (G : sgraph) (V1 V2 : {set G}) (x y : G) : 
+  x != y -> proper_separation V1 V2 -> V1 :&: V2 = [set x; y] ->
+  smallest vseparator (V1 :&: V2) -> kplanar G -> 
+  kplanar (@induced (add_edge G x y) V1) /\ kplanar (@induced (add_edge G x y) V2).
+Proof.
+move => xDy psepV capVxy ssepV [K33G K5G].
+have exV1 := add_edge_separation_excluded xDy psepV capVxy ssepV.
+split; first by split; apply: exV1.
+move/proper_separation_symmetry in psepV.
+rewrite [V1 :&: V2]setIC in capVxy ssepV.
+have exV2 := add_edge_separation_excluded xDy psepV capVxy ssepV.
+by split; apply: exV2.
+Qed.
+
+Lemma separation_no_isolated (G: sgraph) (V1 V2 : {set G}) : 
+  proper_separation V1 V2 -> smallest vseparator (V1 :&: V2) ->
+  no_isolated G -> no_isolated (induced V1) /\ no_isolated (induced V2).
+Proof.
+move=> sepV smallV no_iso. 
+wlog suff I : V1 V2 sepV smallV / no_isolated (induced V1).
+{ move: (sepV) (smallV) => /proper_separation_symmetry ?; rewrite setIC => ?.
+  by split; apply: I; eassumption. }
+move=> x; have [xV2|xNV2] := boolP (val x \in V2).
+- have xV : val x \in V1 :&: V2 by rewrite inE xV2 (valP x).
+  have [y [? [yNV2 _ xy _]]] := svseparator_neighbours sepV smallV xV.
+  have yV1 : y \in V1 by apply: sep_inL (sepV.1) yNV2. 
+  by exists (Sub y yV1). 
+- have [y xy] := no_iso (val x).
+  suff yV1 : y \in V1 by exists (Sub y yV1).
+  by apply: contraTT xy => ?; rewrite sepV.1.
+Qed.
+
+(** Theorem 8 / Theorem 31 *)
+Theorem Wagner (G : sgraph) :
+  no_isolated G -> ~ minor G 'K_3,3 /\ ~ minor G 'K_5 -> inhabited (plane_embedding G).
+Proof.
+elim/card_ind : G => G IH no_iso.
+have [largeG|smallG _] := ltnP 4 #|G|; last first.
+  exact: small_planar smallG no_iso.
+have [|[S lt3S sepS]] := @connectedVseparator G 3 (ltnW largeG).
+  exact: wagner3.
+wlog ssepS : S lt3S {sepS} / smallest vseparator S.
+{ move=> W; have [B smallB] := ex_smallest (@vseparatorP G) sepS.
+  apply: (W B) => //. apply: leq_trans lt3S. exact: smallB.2. }
+have [V1 [V2 [psepV defS]]] := vseparator_separation ssepS.1.
+have [|no_is1 no_iso2] := separation_no_isolated psepV _ no_iso. 
+  by rewrite -defS.
+move=> kplG.
+have [/cards2P[x[y [xDy Sxy]]]|SN2] := boolP (#|S| == 2).
+{ (* minimal 2-separator, need xy-edge as marker *)
+  pose G1 := @induced (add_edge G x y) V1; pose G2 := @induced (add_edge G x y) V2.
+  have [ltG1 ltG2] : #|G1| < #|G| /\ #|G2| < #|G|.
+    by rewrite !card_sig !(proper_separation_card psepV).
+  have psepV' : @proper_separation (add_edge G x y) V1 V2.
+    by apply: add_edge_proper_separation psepV; rewrite -defS Sxy !inE eqxx.
+  have [no_iso1' no_iso2'] : no_isolated G1 /\ no_isolated G2.
+  { apply: separation_no_isolated => //; last exact: add_edge_no_isolated.
+    by rewrite -defS; apply: add_edge_smallest_vseparator; rewrite // Sxy !inE eqxx. }
+  have [kplanar1 kplanar2] : kplanar G1 /\ kplanar G2.
+    by apply: kplanar_add_edge; rewrite // -?defS.
+  case: (IH G1) => // g1; case (IH G2) => // g2.
+  have sepV : @separation (add_edge G x y) V1 V2.
+    by apply: add_edge_separation psepV.1; rewrite -defS Sxy !inE eqxx.
+  have [] : inhabited (plane_embedding (add_edge G x y)).
+  { apply: (@edge_plane_embedding (add_edge G x y) _ _ x y) sepV g1 g2.
+      by rewrite /edge_rel/= !eqxx xDy.
+    by rewrite -defS. }
+  exact: subgraph_plane_embedding (add_edge_subgraph _ _) no_iso. }
+pose G1 := induced V1; pose G2 := induced V2.
+have [ltG1 ltG2] : #|G1| < #|G| /\ #|G2| < #|G|.
+  by rewrite !card_sig !(proper_separation_card psepV).
+have [[g1] [g2]] : inhabited (plane_embedding G1) /\ inhabited (plane_embedding G2).
+  split; apply: IH => //; apply: kplanar_minor kplG; exact: induced_minor.
+have [/cards1P[x Sx]|SN1] := boolP (#|S| == 1).
+{ (* minimal 1-separator *) 
+  apply: vertex_plane_embedding (psepV.1) g1 g2; rewrite -defS; exact: Sx. }
+have {lt3S SN1 SN2} S0  : S = set0.
+{ apply/cards0_eq/eqP; move: lt3S. 
+  by rewrite 4!(ltnS,leq_eqVlt) (negPf SN1) (negPf SN2) ltnS leqn0. }
+constructor; apply: diso_plane_embedding (@diso_separation _ V1 V2 _ _).
+- exact: union_plane_embedding.
+- exact: psepV.1.
+- by rewrite -setI_eq0 -defS S0.
+Qed.
+
+Print Assumptions Wagner.
+
+(** ** Structural Four-Color Theorem *)
+
+(** Turn the fixed four-element [color] type of the four-color theorem into a [finType] *)
+Section color.
+Let Cs := [:: Color0; Color1 ; Color2; Color3].
+Lemma color_enumP : Finite.axiom Cs. Proof. by case. Qed.
+Lemma color_pcanP : cancel (index^~ Cs) (nth Color0 Cs). Proof. by case. Qed.
+Definition color_countMixin : Countable.mixin_of color := CanCountMixin color_pcanP.
+Definition color_choiceMixin := Countable.ChoiceMixin color_countMixin.
+Canonical color_choiceType := ChoiceType color color_choiceMixin.
+Canonical color_countType := CountType color color_countMixin.
+Definition color_finMixin := Finite.EnumMixin color_enumP. 
+Canonical color_finType := FinType color color_finMixin.
+End color.
+
+Lemma adjn_color (D : hypermap) (k : D -> color) x y : 
+  graph_coloring k -> adjn x y -> k x != k y.
+Proof.
+  case => inv_edge inv_node /exists_inP [z Z1 Z2].
+  have -> : k x = k z by apply: fconnect_invariant Z1.
+  have -> : k y = k (edge z) by apply: fconnect_invariant Z2.
+  move: (inv_edge z) => /= E. by rewrite eq_sym E.
+Qed.
+
+Corollary graph_four_color (D : hypermap) : 
+  loopless D -> planar D -> graph_four_colorable D.
+Proof. 
+  rewrite -four_colorable_dual -planar_dual -bridgeless_dual => ? ?.
+  exact: four_color_hypermap.
+Qed.
+
+Definition sgraph_coloring (G : sgraph) (C : finType) (k : G -> C) := 
+  forall x y : G, x -- y -> k x != k y.
+
+Lemma coloring_of_embedding (G : sgraph) (D : hypermap) (f : D -> G) (k : D -> color) : 
+  embedding f -> graph_coloring k -> exists k' : G -> color, sgraph_coloring k'.
+Proof.
+  move => emb_f [inv_edge inv_node]. exists (k \o emb_inv emb_f).
+  move => x y /=. set dx := emb_inv _ x; set dy := emb_inv _ y.
+  rewrite -[x](_ : f dx = x) -1?[y](_ : f dy = y); try exact: f_iinv.
+  rewrite -emb_edge //. exact: adjn_color.
+Qed.
+
+(** Note that neither [emb_plain] nor [emb_vertex] is required to
+prove the four-color theorem for simple graphs.
+
+[emb_plain] : it doesn't matter whether vertices are adjecent due to
+being on a large multiedge or due to different edges (and faces are
+irrelevant, as long as the map is planar).
+
+[emb_vertex] : if the map is planar even after collapsing vertices,
+the original graph can still be colored. Conversely, when there are
+two node cycles for a vertex, these are not adjecent (by [emb_edge])
+and must both be adjacent to all node cycles representing their
+neighborhood in [G]. Hence, one can pick any of the cycles
+representing a vertex to obtain the coloring (using [emb_surj]). *)
+
+(** Theorem 34 *)
+Corollary sgraph_four_color (G : sgraph) : 
+  kplanar G -> exists k : G -> color, sgraph_coloring k.
+Proof.
+move => kpl.
+wlog no_iso : G kpl / no_isolated G; last first.
+{ have [[D f emb_f planar_D]] := Wagner no_iso kpl.
+  have loopless_D := emb_loopless emb_f.
+  have [k col_k] := graph_four_color loopless_D planar_D.
+  exact: coloring_of_embedding emb_f col_k. }
+move=> W; pose A := [set x : G | [exists y, x -- y]].
+have no_iso : no_isolated (induced A). 
+{ move=> x'; have := valP x'; rewrite inE => /existsP [y xy].
+  suff yA : y \in A by exists (Sub y yA).
+  by rewrite !inE; apply/existsP; exists (val x'); rewrite sgP. }
+have [|k col_k] := W _ _ no_iso.
+  exact: kplanar_minor (induced_minor _) _.
+pose k' (x : G) := 
+  if boolP (x \in A) is AltTrue p then k (Sub x p) else Color0.
+exists k'. move=> x y xy. rewrite /k' !altT ?inE => [||? ?].
+- by apply/existsP; exists y.
+- by apply/existsP; exists x; rewrite sgP.
+- exact: col_k. 
+Qed.
+
+Fact card_color : #|color| = 4.
+Proof. by rewrite cardT enumT unlock. Qed.


### PR DESCRIPTION
This the hypermap part of the formal proof of the main direction of Wagner's theorem. 

Since not everyone may want to compile the four color theorem just to install the graph theory library, `coq-fourcolor` is an optional dependency. If `coq-fourcolor` is installed, then "_CoqProject.wagner" gets appended to `_CoqProject` before building the package. When wanting to build the hypermaps part locally, this step has to be performed manually.
