### PR TITLE
Infrastructure for Wagner's Theorem

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -15,6 +15,7 @@ theories/set_tac.v
 theories/bij.v
 theories/finite_quotient.v
 theories/equiv.v
+theories/arc.v
 
 ## general purpose graph library (JAR19)
 theories/digraph.v
@@ -26,6 +27,7 @@ theories/minor.v
 theories/excluded.v
 theories/checkpoint.v
 theories/cp_minor.v
+theories/smerge.v
 
 ## soundness and completeness for 2pdom (CPP20)
 theories/structures.v

--- a/theories/arc.v
+++ b/theories/arc.v
@@ -1,0 +1,601 @@
+Require Import Setoid Morphisms.
+From mathcomp Require Import all_ssreflect.
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Lemma iter_id (T : Type) n : @iter T n id =1 id.
+Proof. by elim: n. Qed.
+
+Lemma iterK n (T : Type) (f g : T -> T) : 
+  cancel f g -> cancel (iter n f) (iter n g).
+Proof.
+by move => can_fg; elim: n => // n IHn x; rewrite iterS iterSr IHn can_fg.
+Qed.
+
+Lemma leq_subl n m o : n <= m -> n - o <= m.
+Proof. move => A. rewrite -[m]subn0. exact: leq_sub. Qed.
+
+(** ** Lemmas on [rot] *)
+
+Section RotAddMod.
+Variables (T : eqType).
+Implicit Type (s : seq T).
+
+Lemma rot_minn n s : rot n s = rot (minn n (size s)) s.
+Proof.
+by case: (leqP n (size s)) => // /leqW ?; rewrite rot_size rot_oversize.
+Qed.
+
+Definition rot_sum n m s := locked
+  (if minn m (size s) + minn n (size s) <= size s
+   then minn m (size s) + minn n (size s)
+   else minn m (size s) + minn n (size s) - size s).
+
+Lemma leq_rot_sum n m s : rot_sum n m s <= size s.
+Proof. 
+unlock rot_sum. 
+by case:ifP => // _; rewrite -subnBA // ?geq_minr // leq_subl // geq_minr.
+Qed.
+
+Lemma rot_rot_sum n m s : rot m (rot n s) = rot (rot_sum n m s) s.
+Proof. 
+unlock rot_sum.
+by rewrite (rot_minn n) (rot_minn m) rot_add_mod ?size_rot ?geq_minr.
+Qed.
+
+Lemma rot_sumC n m s : rot_sum n m s = rot_sum m n s.
+Proof. by unlock rot_sum; rewrite ![minn n _ + _]addnC. Qed.
+
+End RotAddMod.
+
+(** ** Lemmas on [index], [mask], and [subseq] *)
+(** could go to seq.v *)
+
+Lemma rev_mask (T : Type) (m : bitseq) (s : seq T) : 
+  size m = size s -> rev (mask m s) = mask (rev m) (rev s).
+Proof.
+elim: m s => [|b m IHm] [|x s] //= /eqP m_s.
+have ? : size m = size s by exact/eqP.
+rewrite fun_if !rev_cons -!cats1 IHm // mask_cat ?size_rev //.
+by case: b => //=; rewrite cats0.
+Qed.
+
+Lemma subseq_rev (T : eqType) (s1 s2 : seq T) : 
+  subseq (rev s1) (rev s2) = subseq s1 s2.
+Proof. 
+wlog suff W : s1 s2 / subseq s1 s2 -> subseq (rev s1) (rev s2).
+  by apply/idP/idP => /W //; rewrite !revK.
+move/subseqP => [m size_m mask_m]; apply/subseqP.
+by exists (rev m); rewrite ?size_rev // -rev_mask // -mask_m.
+Qed.
+
+Lemma subseq_cat2l (T : eqType) (l s1 s2 : seq T) : 
+  subseq (l ++ s1) (l ++ s2) = subseq s1 s2.
+Proof. elim: l => // x l IHl. by rewrite !cat_cons /= eqxx. Qed.
+
+Lemma subseq_cat2r (T : eqType) (l s1 s2 : seq T) : 
+  subseq (s1 ++ l) (s2 ++ l) = subseq s1 s2.
+Proof. by rewrite -subseq_rev !rev_cat subseq_cat2l subseq_rev. Qed.
+
+
+Lemma eqseq_pivot (T : eqType) (s1 s2 s3 s4 : seq T) (x : T) :
+  uniq (s3 ++ x :: s4) -> s1 ++ x :: s2 == s3 ++ x :: s4 = (s1 == s3) && (s2 == s4).
+Proof. 
+move=> uniq34; apply/idP/idP => [E|/andP [/eqP-> /eqP->] //].
+suff S : size s1 = size s3 by rewrite eqseq_cat // eqseq_cons eqxx in E.
+gen have I,I1 : s3 s4 uniq34 {E} / size s3 = index x (s3 ++ x :: s4).
+  rewrite index_cat index_head addn0 ifN //.
+  by apply: contraTN uniq34 => x_s3; rewrite cat_uniq /= x_s3 /= andbF.
+by rewrite I1 -(eqP E) -I // (eqP E).
+Qed.
+
+Lemma subseq_pivot (T : eqType) (s1 s2 s3 s4 : seq T) x : 
+  uniq (s3 ++ x :: s4) -> 
+  subseq (s1 ++ x :: s2) (s3 ++ x :: s4) -> subseq s1 s3 /\ subseq s2 s4.
+Proof.
+move => uniq_s' sub_s_s'; have uniq_s := subseq_uniq sub_s_s' uniq_s'. 
+have/eqP {sub_s_s' uniq_s'} := subseq_uniqP uniq_s' sub_s_s'.
+rewrite !filter_cat /= mem_cat inE eqxx orbT /= => E.
+move: (E); rewrite eqseq_pivot -?(eqP E) // => /andP [/eqP -> /eqP ->].
+by rewrite !filter_subseq.
+Qed.
+
+Lemma subseq_rot (T : eqType) (p s : seq T) n : 
+  subseq p s -> exists2 k, k <= n & subseq (rot k p) (rot n s).
+Proof.
+move => /subseqP [m size_m ->]. 
+exists (count id (take n m)); last by rewrite -mask_rot // mask_subseq.
+apply: leq_trans (count_size _ _) _; rewrite size_take.
+by case: (ltnP n (size m)).
+Qed.
+
+
+Lemma mem2_index (T : eqType) (x y : T) (s : seq T) : 
+  uniq s -> y \in s -> mem2 s x y = (index x s <= index y s).
+Proof.
+have [|xNs _ y_s] := boolP (x \in s); last first.
+  by rewrite mem2lf // (memNindex xNs) leqNgt index_mem y_s.
+elim: s => //= z s IHs x_s /andP[zNs uniq_s] y_s; rewrite mem2_cons.
+rewrite y_s; have [-> //|zDx] := eqVneq z x.
+have [<-|zDy] := eqVneq z y;first by rewrite mem2rf. 
+rewrite !inE ?[_ == z]eq_sym ?(negbTE zDy) ?(negbTE zDx) /= in x_s y_s.
+exact: IHs.
+Qed.
+
+Lemma index_subseq (T : eqType) x y (s1 s2 : seq T) :
+  y \in s1 -> subseq s1 s2 -> uniq s2 -> 
+  index x s1 <= index y s1 -> index x s2 <= index y s2.
+Proof.
+move=> y_s1 sub_s1_s2 uniq_s2; have uniq_s1 := subseq_uniq sub_s1_s2 uniq_s2.
+rewrite -!mem2_index ?mem2E // => [?|]; last exact: (mem_subseq sub_s1_s2).
+exact: subseq_trans sub_s1_s2.
+Qed.
+
+
+(** ** Lemmas on [next] and [rot] *)
+(** could go to path.v *)
+
+Section Path.
+
+Lemma eq_traject (T : Type) (f g : T -> T) : f =1 g -> traject f =2 traject g.
+Proof. move=> fg x n; elim: n x => //= n IHn x. by rewrite IHn fg. Qed.
+
+Variable (T : eqType). 
+Implicit Types (s p : seq T) (x y : T).
+
+Lemma head_rot s x0 n : n < size s -> head x0 (rot n s) = nth x0 s n.
+Proof.
+move=> n_lt_s; rewrite /rot -nth0 nth_cat size_drop subn_gt0 n_lt_s.
+by rewrite -{2}[s](cat_take_drop n) nth_cat size_take n_lt_s ltnn subnn.
+Qed.
+
+Lemma next_cons x0 x s : next (x::s) x = head x0 (rcons s x).
+Proof. by case: s => [|y s] /=; rewrite eqxx. Qed.
+
+Lemma next_neq x p : x \in p -> uniq p -> 1 < size p -> x != next p x.
+Proof. 
+move => x_p; have [i p' rot_p uniq_p] := rot_to x_p.
+move: (uniq_p); rewrite -(next_rot i) // -(size_rot i) -(rot_uniq i) {}rot_p.
+case: p' => //= y p'. rewrite inE eqxx. by case: (x == y).
+Qed.
+
+Lemma prev_neq x p : x \in p -> uniq p -> 1 < size p -> x != prev p x.
+Proof.
+move => x_p uniq_p lt1p. have := @next_neq (prev p x) _ _ uniq_p lt1p.
+by rewrite mem_prev next_prev // eq_sym; apply.
+Qed.
+
+Lemma iter_next_rot x0 s n :
+  n < size s -> uniq s -> iter n (next s) (head x0 s) = head x0 (rot n s).
+Proof.
+elim: n s => [|n IHn] s; first by move => *; rewrite rot0.
+case: s => [_ /= |x s]; first by rewrite (@eq_iter _ _ id) ?iter_id.
+move => n_lt_s uniq_s. rewrite iterSr rotS 1?ltnW // rot_rot rot1_cons.
+rewrite (next_cons x0).
+under eq_iter => z do rewrite -(next_rot 1) ?rot1_cons //.
+by rewrite IHn // ?size_rcons ?rcons_uniq // ltnW.
+Qed.
+
+Lemma iter_next_nth x0 s n : 
+  uniq s -> n < size s -> iter n (next s) (head x0 s) = nth x0 s n.
+Proof. by move => *; rewrite iter_next_rot // head_rot. Qed.
+
+Lemma traject_next x0 s : 
+  uniq s -> traject (next s) (head x0 s) (size s) = s.
+Proof. 
+move=> uniq_s; apply: (@eq_from_nth _ x0); rewrite size_traject // => i i_lt_s.
+rewrite (set_nth_default (head x0 s)) ?size_traject //.
+by rewrite nth_traject // iter_next_nth.
+Qed.
+
+Lemma mem_arc (p : seq T) (x y : T) : {subset arc p x y <= p}.
+Proof. by move => z /mem_take; rewrite mem_rot. Qed.
+
+End Path.
+
+Lemma map_arc (aT rT : eqType) (f : aT -> rT) (s : seq aT) (x y : aT) : 
+  injective f -> [seq f z | z <- arc s x y] = arc (map f s) (f x) (f y).
+Proof. 
+by move=> inj_f; rewrite /arc -map_rot !index_map // map_take.
+Qed.
+
+Lemma next_map (aT rT : eqType) (f : aT -> rT) (s : seq aT) (x : aT) : 
+  injective f -> next (map f s) (f x) = f (next s x).
+Proof.
+move=> inj_f; case: s => //= a s.
+by elim: s a {2 4}a => /= [|y s IHs] a b; rewrite inj_eq // ?IHs -fun_if.
+Qed.
+
+(** ** Lemmas on [index] *)
+(** could go to [fingraph.v] *)
+
+Lemma eq_findex (T : finType) (f g : T -> T) : 
+  f =1 g -> findex f =2 findex g.
+Proof. 
+move=> fg x y; rewrite /findex /index /orbit /order (eq_traject fg). 
+congr (_ _ (traject _ _ _)); exact/eq_card/eq_fconnect.
+Qed.
+
+Lemma findex_head (T : finType) (x y : T) (s : seq T) (uniq_xs : uniq (x::s)) :
+  findex (next (x :: s)) x y = index y (x :: s).
+Proof.
+rewrite /findex (_ : orbit (next (x::s)) x = x::s) // /orbit.
+rewrite (@order_cycle _ _ (x::s)) ?mem_head ?cycle_next //.
+exact: (@traject_next _ x).
+Qed.
+
+
+Require Import preliminaries.
+Local Notation splitPr := path.splitPr.
+
+(* Only the lemmas below are actually used: 
+(* already on mathcomp master *)
+Axiom card_gt1P : 
+   forall {T : finType} {A : pred T}, reflect (exists x y : T, [/\ x \in A, y \in A & x != y]) (1 < #|A|).
+Axiom disjointFr :  
+  forall (T : finType) (A B : pred T), reflect (forall x : T, x \in A -> x \in B -> False) [disjoint A & B].
+*)
+
+Lemma head_arc (T: eqType) (s : seq T) (x y : T) (xDy : x != y) : 
+  uniq s -> x \in s -> y \in s -> x \in arc s x y.
+Proof.
+move=>  uniq_s x_s y_s. case: (rot_to_arc uniq_s x_s y_s xDy) => i s1 s2 <- _ _. 
+exact: mem_head.
+Qed.
+
+Lemma next_mem_arc (T : eqType) (s : seq T) (x y : T) : 
+  uniq s -> x \in s -> y \in s -> x != y -> next s x \in rcons (arc s x y) y.
+Proof.
+move=> uniq_s x_s y_s xDy.
+have [i s1 s2 arc1 arc2 rot_r] := rot_to_arc uniq_s x_s y_s xDy.
+rewrite -arc1 -(next_rot i) // rot_r (next_cons x).
+by case: s1 {arc1 rot_r} => [|z s1']; rewrite /= !inE eqxx orbT.
+Qed.
+
+(* Not used *)
+Lemma arc_next (T : eqType) (s : seq T) (x : T) : 
+  1 < size s -> uniq s -> x \in s -> arc s x (next s x) = [:: x].
+Proof. 
+move=> le2s uniq_s x_s. 
+have xDnx : x != next s x by apply: next_neq.
+have nx_s : next s x \in s by rewrite mem_next.
+have [i s1 s2 A1 A2 rot_i] := rot_to_arc uniq_s x_s nx_s xDnx.
+suff s1nil : s1 = [::] by rewrite -A1 s1nil.
+move: (uniq_s); rewrite -(rot_uniq i) rot_i -(next_rot i) // rot_i (next_cons x).
+by case: s1 {A1 A2 rot_i} => //= y s1'; rewrite !(inE,mem_cat) eqxx orbT andbF.
+Qed.
+
+
+Definition path0 (T : Type) (e : rel T) (s : seq T) :=
+  if s is x::s then path e x s else true.
+
+Lemma path_path0 (T : Type) (e : rel T) x (s : seq T) : 
+  path e x s -> path0 e s.
+Proof. by case: s => //= y s /andP [_]. Qed.
+
+
+Section UcycleArc.
+Variables (T : finType) (e : rel T) (s : seq T).
+
+Lemma arc_path x y (xDy : x != y) :
+  ucycle e s -> x \in s -> y \in s -> path0 e (arc s x y).
+Proof.
+move=> /andP[cycle_s uniq_s] x_s y_s. 
+have [i s1 s2 <- _ E /=] := rot_to_arc uniq_s x_s y_s xDy.
+move: cycle_s. rewrite -(rot_cycle i) E /= rcons_path cat_path.
+by case: (path e x s1).
+Qed.
+
+Lemma arc_edge x y : 
+  ucycle e s -> x \in s -> y \in s -> x != y -> e (last x (arc s x y)) y.
+Proof.
+move => /andP [cycle_s uniq_s] x_s y_s xDy.
+have [n s1 s2 <- _ rot_s] := rot_to_arc uniq_s x_s y_s xDy.
+move: cycle_s; rewrite -(rot_cycle n) {}rot_s /=.
+by rewrite rcons_path cat_path /=; case: (e (last _ _) _); rewrite // andbF.
+Qed.
+
+Lemma arc_findex x y z (xDy : x != y) : 
+  uniq s -> x \in s -> y \in s -> 
+  (z \in arc s x y) = (findex (next s) x z < findex (next s) x y).
+Proof.
+move=> uniq_s x_s y_s; have [i s1 s2 A1 A2 R] := rot_to_arc uniq_s x_s y_s xDy.
+under eq_findex => u do rewrite -(next_rot i) //.
+under (@eq_findex _ (next s)) => u do rewrite -(next_rot i) //.
+have uniq_xy : uniq (x :: s1 ++ y :: s2) by rewrite -R rot_uniq.
+rewrite R !findex_head // -cat_cons !index_cat index_head.
+rewrite -A1 [X in _ < X]ifN. 
+  by case: ifP => [Hz|_]; rewrite ?ltn_add2l // addn0 index_mem Hz.
+by apply: contraTN uniq_xy => C; rewrite -cat_cons cat_uniq /= C /= andbF.
+Qed.
+
+Lemma arc_disjoint2 x y : 
+  uniq s -> x \in s -> y \in s -> x != y -> [disjoint arc s x y & arc s y x].
+Proof.
+move => uniq_s x_s y_s xDy.
+have [n s1 s2 <- <- rot_s] := rot_to_arc uniq_s x_s y_s xDy.
+move: uniq_s; rewrite -(rot_uniq n) rot_s -cat_cons cat_uniq. 
+by rewrite disjoint_sym disjoint_has => /and3P [_ -> _].
+Qed.
+
+Lemma arc_disjoint x1 x2 y1 y2 : 
+  uniq s -> x1 \in s -> x2 \in s -> y1 \in s -> y2 \in s -> x1 != x2 -> y1 != y2 ->
+  findex (next s) x1 x2 <= findex (next s) x1 y1 ->
+  findex (next s) y1 y2 <= findex (next s) y1 x1 ->
+  [disjoint arc s x1 x2 & arc s y1 y2].
+Proof.
+move=> uniq_s x1_s x2_s y1_s y2_s x1Dx2 y1Dy2 index_x index_y.
+have x1Dy1 : x1 != y1. 
+{ apply: contraNneq x1Dx2 => ?; subst y1. 
+  by move: index_x; rewrite findex0 leqn0 findex_eq0. }
+apply/pred0Pn => -[x] /=; rewrite !arc_findex // => /andP [A1 A2].
+have {A1 index_x} := leq_trans A1 index_x.
+have {A2 index_y} := leq_trans A2 index_y.
+rewrite -!arc_findex //= 1?eq_sym // => x_arc.
+by apply/negP; rewrite (disjointFl (@arc_disjoint2 x1 y1  _ _ _ _)).
+Qed.
+
+Variable p : seq T.
+Hypothesis uniq_s : uniq s.
+Hypothesis p_sub_s : subseq p s.
+Let p_in_s := mem_subseq p_sub_s.
+Let uniq_p := subseq_uniq p_sub_s uniq_s.
+
+Lemma findex_next_other (x y : T) :
+  x \in p -> y \in p -> x != y -> findex (next s) x (next p x) <= findex (next s) x y.
+Proof.
+move=> x_p y_p xDy; have x_s : x \in s by apply: p_in_s.
+have [n s' rot_n] := rot_to x_s.
+under eq_findex => z do rewrite -(next_rot n) //.
+under [X in _ <= X]eq_findex => z do rewrite -(next_rot n) //.
+have uniq_xs : uniq (x :: s') by rewrite -rot_n rot_uniq.
+have [m _ sub] := subseq_rot n p_sub_s.
+rewrite rot_n !findex_head // -(next_rot m) //; rewrite rot_n in sub. 
+have [p' P] : exists p', rot m p = x :: p'. 
+{ rewrite -(mem_rot m) in x_p; rewrite -(rot_uniq m) in (uniq_p).
+  case: (splitPr x_p) sub => p1 p2. rewrite -[x::s']cat0s.
+  move/subseq_pivot => /(_ uniq_xs). 
+  by rewrite subseq0 => -[/eqP -> _]; exists p2. }
+rewrite P next_nth mem_head index_head.
+case: p' P => [|y' p' P]; first by rewrite /= eqxx leq0n.
+rewrite [nth _ _ _]/= P in sub *; apply: index_subseq sub _ _ => //.
+  by rewrite -P mem_rot.
+by rewrite /= eqxx (negbTE xDy); case: (x == y').
+Qed.
+
+Lemma arc_next_disjoint x y : 
+  x \in p -> y \in p -> x != y ->
+  [disjoint arc s x (next p x) & arc s y (next p y)].
+Proof.
+move=> x_p y_p xDy. 
+have x_s : x \in s by apply p_in_s.
+have ? : 1 < size p.
+{ apply: leq_trans (card_size _). by apply/card_gt1P; exists x,y. }
+apply: arc_disjoint; try apply: p_in_s; rewrite ?mem_next //.
+1-2: exact: next_neq.
+all: by apply: findex_next_other; rewrite // eq_sym.
+Qed.
+
+Lemma arc_cover x y : x \in s -> y \in s -> x != y -> s =i [predU arc s x y & arc s y x].
+Proof.
+move=> x_s y_s xDy z; have [i s1 s2 A1 A2 def_s] := rot_to_arc uniq_s x_s y_s xDy.
+by rewrite -(mem_rot i) def_s -cat_cons A1 A2 mem_cat.
+Qed.
+
+Lemma mem_arc_other x y z : x \in s -> y \in s -> z \in s -> x != y -> 
+  (z \in arc s x y) = (z \notin arc s y x).
+Proof.
+move=> x_s y_s z_s xDy; have/esym := arc_cover x_s y_s xDy z; rewrite z_s inE /=.
+have D := arc_disjoint2 uniq_s x_s y_s xDy.
+by case/orP => z_arc; rewrite z_arc ?(disjointFr D) // ?(disjointFl D).
+Qed.
+
+Lemma arc_remainder x : 1 < size p -> x \in p -> {subset p <= rcons (arc s (next p x) x) x}.
+Proof.
+move=> gt1p x_p y y_p; rewrite mem_rcons inE; have [//|xDy/=] := eqVneq x y.
+rewrite mem_arc_other ?p_in_s ?mem_next // 1?eq_sym ?next_neq //.
+have D := arc_next_disjoint x_p y_p xDy. 
+by rewrite (disjointFl D) // head_arc ?p_in_s ?next_neq ?mem_next.
+Qed.
+
+End UcycleArc.
+
+Section SubCycle.
+Variables (T : eqType).
+Implicit Types (p s : seq T).
+
+Definition subcycle p s := [exists n : 'I_(size p).+1, subseq (rot n p) s].
+
+Lemma subcycleP p s : reflect (exists n, subseq (rot n p) s) (subcycle p s).
+Proof.
+apply: (iffP existsP) => [[n On]|[n rot_n]]; first by exists n.
+have [lt_p|ge_p] := ltnP n (size p).+1; first by exists (Ordinal lt_p).
+by exists (Ordinal (ltn0Sn _)); rewrite /= rot0 -[p](@rot_oversize _ n) // ltnW.
+Qed.
+
+Lemma subcycle_rot_l n p s : subcycle (rot n p) s = subcycle p s.
+Proof. 
+apply/subcycleP/subcycleP => [[m]|[m sub]].
+  rewrite rot_rot_sum => sub; eexists; exact: sub.
+exists (rot_sum ((size (rot n p)) - n) m (rot n p)). 
+by rewrite -rot_rot_sum -/(rotr _ _) rotK.
+Qed.
+
+Lemma subcycle_rot_r n p s : subcycle p (rot n s) = subcycle p s.
+Proof.
+apply/subcycleP/subcycleP => -[m sub].
+  have [k _ sub'] := subseq_rot (size (rot n s) - n) sub.
+  rewrite -/(rotr _ _) rotK rot_rot_sum in sub'; eexists; exact sub'.
+have [k _ sub'] := subseq_rot n sub. 
+by exists (rot_sum m k p); rewrite -rot_rot_sum.
+Qed.
+
+Lemma subcycle_rot n m s p : subcycle (rot n p) (rot m s) = subcycle p s.
+Proof. by rewrite subcycle_rot_l subcycle_rot_r. Qed.
+
+Lemma subseq_subcyle p s : subseq p s -> subcycle p s.
+Proof. by move => sub; apply/subcycleP; exists 0; rewrite rot0. Qed.
+
+Lemma subcycle_trans : transitive subcycle.
+Proof.
+move=> r p q sub_p_r /subcycleP [m sub_r_q].
+move: sub_p_r; rewrite -(subcycle_rot_r m) => /subcycleP [n] sub_p_r.
+by apply/subcycleP; exists n; apply: subseq_trans sub_r_q.
+Qed.
+
+Lemma subcycle_uniq p s : subcycle p s -> uniq s -> uniq p.
+Proof. 
+move=> /subcycleP [n sub_p_s]; rewrite -(rot_uniq n p).
+exact: subseq_uniq.
+Qed.
+
+Lemma mem_subcycle p s : subcycle p s -> {subset p <= s}.
+Proof. 
+move=> /subcycleP[n /mem_subseq sub_p_s] z z_p.
+by apply: sub_p_s; rewrite mem_rot.
+Qed.
+
+Lemma subcycle_get_arc x p s :
+  x \in s -> uniq s -> subcycle p s -> 1 < size p ->
+  exists2 z, z \in p & x \in arc s z (next p z).
+Proof.
+wlog [s' -> _ {s}] : s / exists s', s = x::s'.
+{ move=> W x_s uniq_s sub_p_s size_p; have [i s' rot_i] := rot_to x_s. 
+  case: (W (rot i s)); rewrite ?mem_rot ?rot_uniq ?subcycle_rot_r //; first by exists s'.
+  move=> z z_p; rewrite arc_rot ?(mem_subcycle sub_p_s) //; by exists z. }
+move=> uniq_s sub_p_s size_p. 
+have uniq_p : uniq p by apply: subcycle_uniq uniq_s.
+have [x_p|xNp] := boolP (x \in p).
+- exists x; rewrite ?head_arc ?mem_head //; first exact: next_neq. 
+  apply: mem_subcycle sub_p_s _ _. by rewrite mem_next.
+- have has_p : has (mem p) s'. 
+  {  case: p => [//|z p] in size_p sub_p_s uniq_p xNp *.
+     apply/hasP; exists z; rewrite /= ?mem_head //. 
+     move:(mem_subcycle sub_p_s) => /(_ z (mem_head _ _)) /predU1P [zx|//].
+     by rewrite zx inE eqxx in xNp. }
+  case def_s : _ _ _ _ / (split_find_nth x has_p) => [/= nz s1 s2 nz_p Ns2].
+  pose z := path.prev p nz. 
+  have z_s2 : z \in s2. 
+  { have z_p : z \in p by rewrite path.mem_prev. 
+    move:(mem_subcycle sub_p_s z_p); rewrite inE => /predU1P[zx|].
+      by subst; contrab.
+    rewrite def_s. rewrite mem_cat mem_rcons inE eq_sym (negbTE (prev_neq _ _ _)) //=.
+    by case/orP => [z_s1|//]; apply: contraNT Ns2 => _; apply/hasP; exists z. }
+  exists z; rewrite ?path.mem_prev // next_prev // -cats1 -catA /=.
+  case def_s2 : _ / (path.splitPr z_s2) => [p1 p2]. 
+  have U1 : uniq (x :: s1 ++ nz :: p1 ++ z :: p2).
+  { by rewrite -def_s2 -[nz :: _]cat1s catA cats1 -def_s. }
+  move: (U1). rewrite -cat_cons -(rot_uniq (size (x :: s1))) rot_size_cat => U2.
+  rewrite -cat_cons -(arc_rot (size (x :: s1))) // ?rot_size_cat ?(inE,mem_cat,eqxx,orbT)//.
+  have E : ((nz :: p1) ++ z :: p2) ++ x :: s1 = nz :: p1 ++ z :: (p2 ++ x :: s1).
+  { by rewrite /= -!cat_cons -!catA. }
+  by rewrite E right_arc -?E// !(inE,mem_cat) eqxx /= !orbT.
+Qed.
+
+
+
+End SubCycle.
+
+
+Lemma arc_iterP (T : eqType) (x y z : T) (s : seq T) (xDy : x != y) : 
+  uniq s -> x \in s -> y \in s -> 
+  reflect (exists2 n, iter n (next s) x = z 
+                    & forall m, m <= n -> iter m (next s) x != y) 
+          (z \in arc s x y).
+Proof.
+move=> uniq_s x_s y_s. 
+have [i s1 s2 arc1 arc2 rot_i] := rot_to_arc uniq_s x_s y_s xDy.
+have I k (lt_k_s : k < size (rot i s)) : iter k (next s) x = nth x (rot i s) k.
+{ have -> : x = head z (rot i s) by rewrite rot_i.
+  under eq_iter => u do rewrite -(next_rot i) //.
+  by rewrite iter_next_nth // ?rot_uniq // (set_nth_default z). }
+have yNarc1 : y \notin arc s x y. 
+{ apply: contraTN uniq_s; rewrite -(rot_uniq i) rot_i -cat_cons arc1 cat_uniq.
+  move=> y_arc1; rewrite [has _ _](_ : _ = true) ?andbF //.
+  by apply/hasP; exists y => //=; apply: mem_head. }
+apply: (iffP idP) => [z_arc1|[n iter_n min_n]].
+- have z_s := mem_arc z_arc1; exists (index z (rot i s)) => [|m lt_m_z].
+    rewrite I ?nth_index // ?mem_rot // index_mem. 
+    by rewrite rot_i -cat_cons arc1 mem_cat z_arc1.
+   have lt_m_a1 : m < size (arc s x y). 
+   { apply: leq_ltn_trans lt_m_z _.
+     by rewrite rot_i -cat_cons arc1 index_cat z_arc1 index_mem. }
+   have m_lt_s : m < size (rot i s). 
+     by apply: leq_trans lt_m_a1 _; rewrite rot_i -cat_cons arc1 size_cat leq_addr.
+   apply: contraNneq yNarc1; rewrite I // => {1}<-.
+   by rewrite rot_i -cat_cons arc1 nth_cat lt_m_a1 mem_nth.
+- pose k := index y (rot i s); have lt_k_s : k < size (rot i s).
+    by rewrite index_mem rot_i !(inE,mem_cat) eqxx !orbT.
+  have lt_n_k : n < k. 
+    rewrite ltnNge; apply/negP=> /min_n.
+    by rewrite I // nth_index ?eqxx // rot_i !(inE,mem_cat) eqxx !orbT.
+  rewrite -iter_n I ?(ltn_trans lt_n_k lt_k_s) // rot_i -cat_cons arc1 nth_cat.
+  suff eq_k : k = size (arc s x y) by   rewrite -eq_k lt_n_k mem_nth // -eq_k.
+  by rewrite /k rot_i -cat_cons arc1 index_cat (negbTE yNarc1) /= ?eqxx ?addn0.
+Qed.
+
+Lemma next_iter (T : eqType) (x y : T) (s : seq T) :
+  uniq s -> x \in s -> y \in s -> exists n, iter n (next s) x == y.
+Proof. 
+move=> uniq_s x_s y_s; have [i s' rot_i] := rot_to x_s.
+exists (index y (rot i s)); under eq_iter => z do rewrite -(next_rot i) //.
+have -> : x = head y (rot i s) by rewrite rot_i. 
+by rewrite iter_next_nth ?nth_index ?index_mem ?mem_rot ?rot_uniq.
+Qed.
+
+Lemma prev_iter (T : eqType) (x y : T) (s : seq T) :
+  uniq s -> x \in s -> y \in s -> exists n, iter n (prev s) x == y.
+Proof.
+move=> uniq_s x_s y_s; have [n /eqP eq_x] := next_iter uniq_s y_s x_s.
+by exists n; rewrite -eq_x iterK //; apply: prev_next.
+Qed.
+
+Lemma subcycle_get_arc' (T : eqType) x (p s : seq T) : 
+  x \in s -> uniq s -> subcycle p s -> 1 < size p ->
+  exists2 z, z \in p & x \in arc s z (next p z).
+Proof.
+move=> x_s uniq_s sub_p_s le2p. 
+have mem_s := mem_subcycle sub_p_s.
+have uniq_p : uniq p by apply: subcycle_uniq uniq_s.
+have /ex_minnP [n iter_n min_n] : exists n, iter n (prev s) x \in p.
+  move/leqW : le2p; rewrite ltnS -has_predT => /hasP [z z_p _].
+  have [n /eqP it_n] := next_iter uniq_s (mem_s _ z_p) x_s.
+  by exists n; rewrite -it_n iterK //; exact: prev_next.
+set z := iter n _ _ in iter_n *; exists z => //. 
+have [z_s nz_s] : z \in s /\ next p z \in s by rewrite ?mem_s // ?mem_next.
+apply/arc_iterP; rewrite ?next_neq //.
+have /ex_minnP [m /eqP iter_m min_m] := next_iter uniq_s z_s nz_s.
+exists n => [|n'] ; first exact/iterK/next_prev.
+apply: contraTN => /min_m => le_m_n'. rewrite -ltnNge.
+apply: leq_trans le_m_n' => {n'}. apply: wlog_neg; rewrite -ltnNge => gt_m_n.
+have gt0m : 0 < m. 
+{ by rewrite lt0n; apply: contra_eq_neq iter_m => -> /=; apply: next_neq. }
+have gt0n : 0 < n by apply: leq_trans gt0m _.
+have/min_n : iter (n - m) (prev s) x \in p. 
+{ have En : n = m + (n - m) by rewrite subnKC.
+  move: iter_n. rewrite -mem_next -iter_m /z {1}En iter_add iterK //.
+  exact: next_prev. }
+by rewrite leqNgt ltn_subrL gt0m gt0n.
+Qed.
+
+Lemma arc_subcycle_disjoint (T : finType) (p s : seq T) (x y : T) : 
+  uniq s -> subcycle p s -> x \in p -> y \in p -> x != y -> 
+  [disjoint arc s x (next p x) & arc s y (next p y)].
+Proof.
+move=> uniq_s /subcycleP [m sub_p_s].
+wlog: p {sub_p_s} / subseq p s => [W|?]; last exact: arc_next_disjoint.
+move: (W _ sub_p_s); rewrite !mem_rot !next_rot // -(rot_uniq m).
+all: exact: subseq_uniq uniq_s.
+Qed.
+
+Lemma arc_subcycle_disjoints (T : finType) (p s : seq T) (x y nx ny : T) : 
+  uniq s -> subcycle p s -> x \in p -> y \in p -> x != y -> nx = next p x -> ny = next p y ->
+  [disjoint [set z in arc s x nx] & [set z in arc s y ny]].
+Proof.
+move=> uniq_s subcycle_p x_p y_p xDy next_x next_y.
+under eq_disjoint => z do by rewrite !inE.
+under eq_disjoint_r => z do by rewrite !inE.
+by rewrite next_x next_y; apply: (arc_subcycle_disjoint uniq_s).
+Qed.

--- a/theories/bij.v
+++ b/theories/bij.v
@@ -60,6 +60,8 @@ Proof. by rewrite -{1}[y](bijK' f) bij_eq. Qed.
 
 Definition bij_id {A}: bij A A := @Bij A A id id (@erefl A) (@erefl A).
 
+Definition bij_ord {T : finType} : bij T 'I_#|T| := Bij enum_rankK enum_valK.
+
 Definition bij_sym {A B}: bij A B -> bij B A.
 Proof. move=>f. econstructor; apply f. Defined.
 
@@ -71,7 +73,6 @@ Defined.
 
 Instance bij_Equivalence: Equivalence bij.
 Proof. constructor. exact @bij_id. exact @bij_sym. exact @bij_comp. Defined.
-
 
 (* bijections about [sum] *)
 

--- a/theories/digraph.v
+++ b/theories/digraph.v
@@ -54,7 +54,7 @@ Implicit Types (x y : T) (p : seq T).
 
 Definition pathp x y p := path (--) x p && (last x p == y).
 
-Lemma pathpW y x p : pathp x y p -> path edge_rel x p.
+Lemma pathpW y x p : pathp x y p -> path (--) x p.
 Proof. by case/andP. Qed.
 
 Lemma pathp_last y x p : pathp x y p -> last x p = y.
@@ -84,7 +84,7 @@ Proof. by rewrite -cat1s pathp_cat {1}/pathp /= eqxx !andbT. Qed.
 Lemma pathp_rcons x y z p: pathp x y (rcons p z) -> y = z.
 Proof. case/andP => _ /eqP <-. exact: last_rcons. Qed.
 
-Lemma rcons_pathp x y p : path edge_rel x (rcons p y) = pathp x y (rcons p y).
+Lemma rcons_pathp x y p : path (--) x (rcons p y) = pathp x y (rcons p y).
 Proof. by rewrite /pathp last_rcons eqxx andbT. Qed.
 
 CoInductive pathp_split z x y : seq T -> Prop := 
@@ -108,7 +108,7 @@ Definition upath x y p := uniq (x::p) && pathp x y p.
 Lemma upathW x y p : upath x y p -> pathp x y p.
 Proof. by case/andP. Qed.
 
-Lemma upathWW x y p : upath x y p -> path edge_rel x p.
+Lemma upathWW x y p : upath x y p -> path (--) x p.
 Proof. by move/upathW/pathpW. Qed.
 
 Lemma upath_uniq x y p : upath x y p -> uniq (x::p).
@@ -426,7 +426,6 @@ Prenex Implicits di_edge.
 
 Notation diGraph := relType.
 Notation DiGraph := RelType.
-Notation di_edge := edge_rel (only parsing).
 Goal forall (T : diGraph) (A : pred T), A \subset [set: T]. by []. Qed.
 
 Section DiGraphTheory.
@@ -448,13 +447,13 @@ Proof.
   apply/negP. apply: disjointE C _. by rewrite -(pathp_last sp1) // mem_last. 
 Qed.
 
-Lemma upathP x y : reflect (exists p, upath x y p) (connect di_edge x y).
+Lemma upathP x y : reflect (exists p, upath x y p) (connect (--) x y).
 Proof.
   apply: (iffP connectP) => [[p p1 p2]|[p /and3P [p1 p2 /eqP p3]]]; last by exists p.
   exists (shorten x p). case/shortenP : p1 p2 => p' ? ? _ /esym/eqP ?. exact/and3P. 
 Qed.
 
-Lemma pathpP x y : reflect (exists p, pathp x y p) (connect di_edge x y).
+Lemma pathpP x y : reflect (exists p, pathp x y p) (connect (--) x y).
 Proof. 
   apply: (iffP idP) => [|[p] /andP[A /eqP B]]; last by apply/connectP; exists p.
   case/upathP => p /upathW ?. by exists p.
@@ -528,14 +527,14 @@ Qed.
 End Fixed.
 
 Lemma connect_irredP x y : 
-  reflect (exists p : Path x y, irred p) (connect di_edge x y).
+  reflect (exists p : Path x y, irred p) (connect (--) x y).
 Proof.
   apply: (iffP (upathP _ _)) => [[p /andP [U P]]|[p I]].
   + exists (Sub p P).  by rewrite /irred nodesE.
   + exists (val p). apply/andP;split; by [rewrite /irred nodesE in I| exact: valP].
 Qed.
 
-Lemma Path_connect x y (p : Path x y) : connect di_edge x y.
+Lemma Path_connect x y (p : Path x y) : connect (--) x y.
 Proof. apply/pathpP. exists (val p). exact: valP. Qed.
 
 
@@ -644,7 +643,7 @@ Qed.
 paths are never empty *)
 Lemma connect_irredRP {A : pred D} x y : x != y ->
   reflect (exists2 p: Path x y, irred p & p \subset A) 
-          (connect (restrict A edge_rel) x y).
+          (connect (restrict A (--)) x y).
 Proof.
   move => Hxy. apply: (iffP connect_restrictP) => //.
   - case => p [pth_p lst_p uniq_p sub_A]. 
@@ -657,8 +656,8 @@ Qed.
 
 (* This is only useful if the [x = y] case does not require [x \in A] *)
 Lemma connect_restrict_case x y (A : pred D) : 
-  connect (restrict A edge_rel) x y -> 
-  x = y \/ [/\ x != y, x \in A, y \in A & connect (restrict A edge_rel) x y].
+  connect (restrict A (--)) x y -> 
+  x = y \/ [/\ x != y, x \in A, y \in A & connect (restrict A (--)) x y].
 Proof.
   case: (altP (x =P y)) => [|? conn]; first by left. 
   case/connect_irredRP : (conn) => // p _ /subsetP subA. 
@@ -666,7 +665,7 @@ Proof.
 Qed.
 
 Lemma connectRI (A : pred D) x y (p : Path x y) :
-  {subset p <= A} -> connect (restrict A edge_rel) x y.
+  {subset p <= A} -> connect (restrict A (--)) x y.
 Proof. 
   case: (boolP (x == y)) => [/eqP ?|]; first by subst y; rewrite connect0. 
   move => xy subA. apply/connect_irredRP => //. case: (uncycle p) => p' p1 p2.

--- a/theories/excluded.v
+++ b/theories/excluded.v
@@ -372,15 +372,6 @@ Proof.
     apply: contraTT. by rewrite ltnNge negbK.
 Qed.
 
-Lemma add_edge_separation (G : sgraph) V1 V2 s1 s2:
-  @separation G V1 V2 -> s1 \in V1:&:V2 -> s2 \in V1:&:V2 ->
-  @separation (add_edge s1 s2) V1 V2.
-Proof.
-  move => sep s1S s2S. split; first by move => x; apply sep.  
-  move => x1 x2 x1V2 x2V1 /=. rewrite /edge_rel/= sep //=.
-  apply: contraTF isT. case/orP => [] /and3P[_ /eqP ? /eqP ?]; by set_tac.
-Qed.
-
 Theorem TW2_of_K4F (G : sgraph) :
   K4_free G -> exists (T : forest) (B : T -> {set G}), sdecomp T G B /\ width B <= 3.
 Proof.
@@ -439,7 +430,7 @@ Proof.
   wlog [phi rmapphi HphiV1] : {K4G'} V1 V2 psep SV12 / exists2 phi : K4 -> {set add_edge s1 s2},
          minor_rmap phi & forall x : K4, phi x \subset V1.
   { move => W.  case: (@separation_K4side (add_edge s1 s2) V1 V2) => //.
-    - apply: add_edge_separation psep.1 _ _; by rewrite -SV12 S12 !inE eqxx.
+    - apply: add_edge_separation psep.1; by rewrite -SV12 S12 !inE eqxx.
     - rewrite -SV12 S12. apply: clique2. by rewrite /edge_rel/= !eqxx s1Ns2. 
     - by rewrite -SV12 S12 cards2 s1Ns2. 
     - move => phi map_phi [subV1|subV2]; first by apply: (W V1 V2) => //; exists phi.

--- a/theories/extraction_def.v
+++ b/theories/extraction_def.v
@@ -40,6 +40,7 @@ Ltac normH := match goal
   | [ H : is_true (_ == _) |- _] => move/eqP : H 
   end.
 Ltac elim_ops := rewrite -multE -plusE -!(rwP leP).
+
 Ltac slia := repeat normH; elim_ops; intros; lia.
 
 Lemma measure_card (G' G : graph2) : 

--- a/theories/extraction_def.v
+++ b/theories/extraction_def.v
@@ -307,7 +307,7 @@ Proof.
   - move/pathp_nil/val_inj ->. exact: connect0.
   - rewrite pathp_cons /= -!andbA => /and5P [A B C D E].
     apply: (connect_trans (y := Sub a B)); last exact: IH.
-    apply: connect1. move: C. rewrite /sk_rel -val_eqE.
+    apply: connect1. move: C. rewrite /edge_rel/=/sk_rel -val_eqE.
     by rewrite adjacent_induced.
 Qed.
 

--- a/theories/mgraph.v
+++ b/theories/mgraph.v
@@ -819,7 +819,7 @@ Variables (G : graph) (V : {set G}) (E : {set edge G}).
 Hypothesis con : consistent V E. 
 
 Lemma subgraph_sub : subgraph (subgraph_for con) G.
-Proof. exists val, val, xpred0. split => //=. split; exact: val_inj. Qed.
+Proof. exists val, val, xpred0. split => //=. Qed.
 
 Lemma remove_edges_sub : subgraph (remove_edges E) G.
 Proof. exists id, val, xpred0. split => //=. split. apply inj_id. apply val_inj. Qed.

--- a/theories/minor.v
+++ b/theories/minor.v
@@ -13,9 +13,6 @@ Set Bullet Behavior "Strict Subproofs".
 
 (** * Minors *)
 
-(** H is a minor of G -- The order allows us to write [minor G] for the
-collection of [G]s minors *)
-
 Definition minor_map (G H : sgraph) (phi : G -> option H) := 
   [/\ (forall y : H, exists x : G, phi x = Some y),
      (forall y : H, connected (phi @^-1 Some y)) &
@@ -102,6 +99,8 @@ Proof.
   by erewrite (disjointFr (map _ _ iNj)).
 Qed.
 
+(** H is a minor of G -- The order allows us to write [minor G] for the
+collection of [G]s minors *)
 Definition minor (G H : sgraph) : Prop := exists phi : G -> option H, minor_map phi.
 
 Fact minor_of_map (G H : sgraph) (phi : G -> option H): 
@@ -424,26 +423,6 @@ Qed.
 
 (** ** Excluded-Minor Characterization of Forests *)
 
-(* TODO: use this whenever explicitly exhibiting a minor map *)
-Lemma minor_rmapI (G H : sgraph) (phi : H -> {set G}) (f : H -> nat) : 
-  injective f ->
-  (forall x : H, phi x != set0) -> 
-  (forall x : H, connected (phi x)) -> 
-  (forall x y : H, f x < f y -> [disjoint phi x & phi y]) ->
-  (forall x y : H, f x < f y -> x -- y -> neighbor (phi x) (phi y)) ->
-  minor_rmap phi.
-Proof.
-  move => inj_f M1 M2 M3 M4. split => // x y xy.
-  - wlog: x y xy / f x < f y; last exact: M3.
-    move => W. case: (ltngtP (f x) (f y)); first exact: W.
-    + rewrite disjoint_sym eq_sym in xy *. exact: W.
-    + move/inj_f => E. by rewrite E eqxx in xy.
-  - wlog: x y xy / f x < f y; last by move => Hf; exact: M4 Hf xy.
-    move => W. case: (ltngtP (f x) (f y)); first exact: W.
-    + rewrite neighborC sgP in xy *. exact: W.
-    + move/inj_f => E. by rewrite E sgP in xy.
-Qed.
-
 Lemma non_forerst_K3 (G : sgraph) : ~ is_forest [set: G] -> minor G 'K_3.
 Proof.
   move/is_forestP/is_forestPn => [x0] [y0] [p0] [q0] [_ _ pDq].
@@ -460,13 +439,13 @@ Proof.
   have xDy : x != y. 
   { apply: contra_neq p1_ne => ?; subst y. 
     by rewrite /path_of_ipath (irredxx (valP p1)) interior_idp. }
-  apply: minor_rmapI; first exact: ord_inj.
+  apply: ordered_rmap; first exact: ord_inj; split.
   - case => [[|[|[|i]]] Hi] //=; [exact: set10 | exact: setU1_neq]. 
   - case => [[|[|[|i]]] Hi] //=. 
     + exact: connected1. 
     + exact: connected_interior.
     + exact: connected_interiorR.
-  - case => [[|[|[|i]]] Hi]; case => [[|[|[|j]]] Hj] //= _.
+  - case => [[|[|[|i]]] Hi]; case => [[|[|[|j]]] Hj] //= _ _.
     + by rewrite disjoints1 !inE eqxx.
     + by rewrite disjoints1 !inE eqxx (negbTE xDy).
     + rewrite disjoint_sym disjointsU // ?disjoints1 1?disjoint_sym //.

--- a/theories/preliminaries.v
+++ b/theories/preliminaries.v
@@ -1,3 +1,4 @@
+Require Import Setoid Morphisms.
 From mathcomp Require Import all_ssreflect.
 Require Import edone.
 
@@ -18,8 +19,22 @@ Proof. exact: mem_imset. Qed.
 
 (** *** Tactics *)
 
-(*Axiom admitted_case : False.
-Ltac admit := case admitted_case.*)
+(** *** Tactics *)
+
+(** Coq treats axioms of type [False] specially: the [Print Asssumptions] command
+prints the types that are inhabited by an (empty) case analysis on the
+axiom. The alternative definition of [admit] below allows closing proofs that
+contain admits by [Qed], leading to a more precise tracking of the "holes"
+during proof development.
+
+Of course, the axiom makes the global context inconsistent, making it necessary
+to check final results using [Print Assumptions] to ensure the axiom is not
+acually used. *)
+
+(** The tactics below should be commented out in released and review versions. *)
+
+(* Axiom admitted_case : False. *) 
+(* Ltac admit := case admitted_case. *)
 
 Ltac reflect_eq := 
   repeat match goal with [H : is_true (_ == _) |- _] => move/eqP : H => H end.
@@ -50,6 +65,32 @@ Qed.
 Lemma enum_unit (p : pred unit) : enum p = filter p [:: tt].
 Proof. by rewrite /enum_mem unlock. Qed.
 
+(** usage: [rewrite [pat]rwT] replaces [pat] with [true] and creates [pat] as a subgoal *)
+Definition rwT (b : bool) := @id (is_true b).
+(** [rewrite [pat]rwF] replaces [pat] with [false] and creates [~~ pat] as a subgoal *)
+Definition rwF := negbTE.
+
+Lemma insubdT (T : Type) (P : pred T) (sT : subType P) (d : sT) (x : T) (Px : P x) : 
+  insubd d x = Sub x Px.
+Proof. by rewrite /insubd insubT. Qed.
+
+Section Val2.
+Variables (T : Type) (P : pred T) (sT : subType P) (P' : pred sT) (sT' : subType P').
+Definition val2 (x : sT') := val (val x).
+
+Lemma val2_inj : injective val2.
+Proof. by apply:inj_comp; apply: val_inj. Qed.
+End Val2.
+Prenex Implicits val2.
+
+Variant xchoose_spec (T : choiceType) (P : pred T) (E : ex P) : T -> Prop :=
+  XChosen x of P x : xchoose_spec E x.
+
+Lemma xchooseP' (T : choiceType) (P : pred T) (E : ex P) : 
+  xchoose_spec E (xchoose E).
+Proof. constructor; exact: xchooseP. Qed.
+
+
 (** The [contra] lemmas below have been proposed for inclusion in Coq/mathcomp 
     (https://github.com/math-comp/math-comp/pull/499) *)
 
@@ -63,7 +104,7 @@ Lemma contraNnot (b : bool) (P : Prop) : (P -> b) -> (~~ b -> ~ P).
 Proof. rewrite -{1}[b]negbK; exact: contraTnot. Qed.
 
 Lemma contraPT (P : Prop) (b : bool) : (~~ b -> ~ P) -> P -> b.
-Proof. by case: b => //= /(_ isT) nP /nP. Qed.
+Proof. case: b => //= H1 H2. by case: (H1 isT H2). Qed.
 
 Lemma contra_notT (b : bool) (P : Prop) : (~~ b -> P) -> ~ P -> b.
 Proof. by case: b => //= /(_ isT) HP /(_ HP). Qed.
@@ -80,6 +121,14 @@ Proof. by move => ?; by apply: contraPN => /eqP. Qed.
 Lemma contraPeq (T:eqType) (a b : T) (P : Prop) : (a != b -> ~ P) -> (P -> a = b).
 Proof. move => Hab HP. by apply: contraTeq isT => /Hab /(_ HP). Qed.
 
+Lemma exists_inPnn {T : finType} {D P : pred T} : 
+  reflect (forall x : T, x \in D -> P x) (~~ [exists x in D, ~~ P x]).
+Proof. 
+rewrite negb_exists_in; under eq_forallb => ? do rewrite negbK.
+exact: forall_inP.
+Qed.
+
+
 
 Lemma existsb_eq (T : finType) (P Q : pred T) : 
   (forall b, P b = Q b) -> [exists b, P b] = [exists b, Q b].
@@ -89,11 +138,10 @@ Lemma existsb_case (P : pred bool) : [exists b, P b] = P true || P false.
 Proof. apply/existsP/idP => [[[|] -> //]|/orP[H|H]]; eexists; exact H. Qed.
 
 Lemma all_cons (T : eqType) (P : T -> Prop) a (s : seq T) : 
-  (forall x, x \in a :: s -> P x) <-> (P a) /\ (forall x, x \in s -> P x).
+  {in a::s, forall x, P x} <-> P a /\ {in s, forall x, P x}.
 Proof.
-  split => [A|[A B]]. 
-  - by split => [|b Hb]; apply: A; rewrite !inE ?eqxx ?Hb. 
-  - move => x /predU1P [-> //|]. exact: B.
+split => [A|[A B]]; last by move => x /predU1P [-> //|]; apply: B.
+by split => [|b Hb]; apply: A; rewrite !inE ?eqxx ?Hb. 
 Qed.
 
 Lemma cons_subset (T : eqType) (a:T) s1 (s2 : pred T) : 
@@ -181,16 +229,13 @@ move => ?. elim/big_ind2 : _ => // y1 y2 x1 x2 A B.
 by rewrite geq_max !leq_max A B orbT.
 Qed.
 
-Lemma leq_subn n m o : n <= m -> n - o <= m.
-Proof. move => A. rewrite -[m]subn0. exact: leq_sub. Qed.
-
 Lemma set1_inj (T : finType) : injective (@set1 T).
 Proof. move => x y /setP /(_ y). by rewrite !inE eqxx => /eqP. Qed.
 
 Lemma id_bij T : bijective (@id T).
 Proof. exact: (Bijective (g := id)). Qed.
 
-Lemma set2C (T : finType) (x y : T) : [set x;y] = [set y;x].
+Lemma set2C (T : finType) (x y : T) : [set x;y] = [set y;x]. 
 Proof. apply/setP => z. apply/set2P/set2P; tauto. Qed.
 
 Lemma card_ltnT (T : finType) (p : pred T) x : ~~ p x -> #|p| < #|T|.
@@ -199,6 +244,13 @@ Proof.
   apply/andP; split; first by apply/subsetP.
   apply/subsetPn. by exists x. 
 Qed.
+
+Lemma leq_cardsD1 (T : finType) (a : T) (A : {set T}) : #|A|.-1 <= #|A :\ a|.
+Proof. by rewrite (cardsD1 a); case: (a \in A); case: (#|_|). Qed.
+
+(* what's a good name? *)
+Lemma setUUC (T : finType) (A B : {set T}) : (A :|: B) :&: (~: A :|: B) = B.
+Proof. by apply/setP => z; rewrite !inE; case: (z \in A). Qed.
 
 Lemma setU1_mem (T : finType) x (A : {set T}) : x \in A -> x |: A = A.
 Proof. 
@@ -239,10 +291,7 @@ Qed.
 and their cardinalities can be simplified *)
 
 Lemma cards3 (T : finType) (a b c : T) : #|[set a;b;c]| <= 3.
-Proof. 
-  rewrite !cardsU !cards1 !addn1. 
-  apply: leq_subn. rewrite ltnS. exact: leq_subn.
-Qed.
+Proof. by rewrite -setUA cardsU1 cards2; case:  (_ \in _); case (_ == _). Qed.
 
 Lemma eq_set1P (T : finType) (A : {set T}) (x : T) : 
   reflect (x \in A /\ {in A, all_equal_to x}) (A == [set x]).
@@ -263,6 +312,27 @@ Qed.
 Lemma take_uniq (T : eqType) (s : seq T) n : uniq s -> uniq (take n s).
 Proof. exact/subseq_uniq/take_subseq. Qed.
 
+Lemma sub_filter (T : eqType) (p : {pred T}) (s : seq T) : 
+  {subset [seq x <- s | p x] <= s}.
+Proof. by move=> x; rewrite mem_filter => /andP[_ ->]. Qed.
+
+Lemma sub_filter_cond (T : eqType) (p : {pred T}) (s : seq T) : 
+  {subset [seq x <- s | p x] <= p}.
+Proof. by move=> x; rewrite mem_filter => /andP[? _]. Qed.
+
+Lemma subseq_of_subset (T : finType) (A : pred T) (s : seq T) n : 
+  uniq s -> {subset A <= s} -> n <= #|A| -> 
+  exists p : seq T, [/\ {subset p <= A}, size p = n & subseq p s].
+Proof.
+move => uniq_s subAs leq_n_A; exists (take n [seq x <- s | x \in A]); split.
+- by move=> x /mem_take; rewrite mem_filter => /andP[->].
+- rewrite size_takel // -(card_uniqP _) ?filter_uniq //.
+  apply: leq_trans leq_n_A _; apply/subset_leq_card/subsetP => x x_A.
+  by rewrite mem_filter x_A subAs.
+- apply: subseq_trans (take_subseq _ _) _. exact: filter_subseq.
+Qed.
+
+(** this is part of mathcomp-1.12, but it's proof could be based on the lemma above *)
 Lemma card_geqP {T : finType} {A : pred T} {n} : 
   reflect (exists s, [/\ uniq s, size s = n & {subset s <= A}]) (n <= #|A|).
 Proof.
@@ -367,17 +437,37 @@ move => ind; elim/card_ind => A IH.
 apply: ind => B /proper_card; exact: IH.
 Qed.
 
-Definition smallest (T : finType) P (U : {set T}) := P U /\ forall V : {set T}, P V -> #|U| <= #|V|.
 
-Lemma below_smallest (T : finType) P (U V : {set T}) : 
-  smallest P U -> #|V| < #|U| -> ~ P V.
+Section Smallest.
+
+Variables (T : finType).
+Implicit Types (P : {set T} -> Prop) (p : {set T} -> bool) (U V : {set T}).
+
+Definition smallest P U := P U /\ forall V : {set T}, P V -> #|U| <= #|V|.
+Definition largest P U := P U /\ forall V : {set T}, P V -> #|V| <= #|U|.
+
+Lemma below_smallest P U V : smallest P U -> #|V| < #|U| -> ~ P V.
 Proof. move => [_ small_U]; rewrite ltnNge; exact/contraNnot/small_U. Qed.
 
-Definition largest (T : finType) P (U : {set T}) := P U /\ forall V : {set T}, P V -> #|V| <= #|U|.
-
-Lemma above_largest (T : finType) P (U V : {set T}) : 
-  largest P U -> #|V| > #|U| -> ~ P V.
+Lemma above_largest P U V : largest P U -> #|V| > #|U| -> ~ P V.
 Proof. move => [_ large_U]. rewrite ltnNge; exact/contraNnot/large_U. Qed.
+
+Variables (P : {set T} -> Prop) (p : {set T} -> bool).
+Hypothesis PP : forall x, reflect (P x) (p x). 
+
+Lemma smallestPP A : smallest P A <-> smallest p A.
+Proof. by split => -[/PP ? H]; split => // ? /PP; apply: H. Qed.
+
+Lemma argmin_smallest A : p A -> smallest p [arg min_(B < A | p B) #|B|].
+Proof. by move=> pA; case: arg_minnP. Qed.
+
+Lemma ex_smallest A : P A -> exists B, smallest P B.
+Proof. 
+move=> /PP PA. exists [arg min_(B < A | p B) #|B|].
+exact/smallestPP/argmin_smallest.
+Qed.
+
+End Smallest.
 
 (** compat:mathcomp-1.10 / in mathcomp-1.11, this will be subsumed by leqP *)
 Inductive maxn_cases n m : nat -> Type := 
@@ -489,6 +579,9 @@ Proof.
   apply/disjointP => x /setUP[]; by move: x; apply/disjointP.
 Qed.
 
+Lemma disjoints0 (T : finType) (A : {set T}) : [disjoint set0 & A].
+Proof. by rewrite eq_disjoint0 // => z; rewrite !inE. Qed.
+
 (** *** Function Update *)
 
 Section update.
@@ -516,6 +609,75 @@ Proof. move => y. rewrite /update. by case: (altP (y =P x)) => [->|]. Qed.
 
 (** *** Sequences and Paths *)
 
+(** from mathcomp-master / will become part of mathcomp-1.12 *)
+(* Generalized versions of splitP (from path.v): split_find_nth and split_find  *)
+Section FindNth.
+Variables (T : Type).
+Implicit Types (x : T) (p : pred T) (s : seq T).
+
+Lemma has_take p s i : has p s -> has p (take i s) = (find p s < i).
+Proof. by elim: s i => [|y s ihs] [|i]//=; case: (p _) => //= /ihs ->. Qed.
+
+Variant split_find_nth_spec p : seq T -> seq T -> seq T -> T -> Type :=
+  FindNth x s1 s2 of p x & ~~ has p s1 :
+    split_find_nth_spec p (rcons s1 x ++ s2) s1 s2 x.
+
+Lemma split_find_nth x0 p s (i := find p s) :
+  has p s -> split_find_nth_spec p s (take i s) (drop i.+1 s) (nth x0 s i).
+Proof.
+move=> p_s; rewrite -[X in split_find_nth_spec _ X](cat_take_drop i s).
+rewrite (drop_nth x0 _) -?has_find// -cat_rcons.
+by constructor; [apply: nth_find | rewrite has_take -?leqNgt].
+Qed.
+
+Variant split_find_spec p : seq T -> seq T -> seq T -> Type :=
+  FindSplit x s1 s2 of p x & ~~ has p s1 :
+    split_find_spec p (rcons s1 x ++ s2) s1 s2.
+
+Lemma split_find p s (i := find p s) :
+  has p s -> split_find_spec p s (take i s) (drop i.+1 s).
+Proof.
+by case: s => // x ? in i * => ?; case: split_find_nth => //; constructor.
+Qed.
+
+Lemma nth_rcons_cat_find x0 p s1 s2 x (s := rcons s1 x ++ s2) :
+   p x -> ~~ has p s1 -> nth x0 s (find p s) = x.
+Proof.
+move=> pz pNs1; rewrite /s  cat_rcons find_cat (negPf pNs1).
+by rewrite nth_cat/= pz addn0 subnn ltnn.
+Qed.
+
+End FindNth.
+
+Lemma eq_in_pmap (aT : eqType) rT (f1 f2 : aT -> option rT) (s : seq aT) : 
+  {in s, f1 =1 f2} -> pmap f1 s = pmap f2 s.
+Proof.
+by elim: s => // a s IHs /all_cons [eq_a eq_s]; rewrite /= eq_a (IHs eq_s).
+Qed.
+
+(** Variants of [splitP] and [splitPr] that remembers that provides
+the information that the split is performed at the first occurrence. *)
+Section SplitPlus.
+Variables (n0 : nat) (T : eqType).
+Implicit Type p : seq T.
+
+Variant split x : seq T -> seq T -> seq T -> Type :=
+  Split p1 p2 of x \notin p1 : split x (rcons p1 x ++ p2) p1 p2.
+
+Lemma splitP p x (i := index x p) :
+  x \in p -> split x p (take i p) (drop i.+1 p).
+Proof. 
+rewrite -has_pred1 => /split_find[? ? ? /eqP->]. 
+by rewrite has_pred1; constructor. 
+Qed.
+
+Variant splitr x : seq T -> Type :=
+  Splitr p1 p2 of x \notin p1 : splitr x (p1 ++ x :: p2).
+
+Lemma splitPr p x : x \in p -> splitr x p.
+Proof. by case/splitP=> p1 p2; rewrite cat_rcons. Qed.
+End SplitPlus.
+
 Lemma tnth_uniq (T : eqType) n (t : n.-tuple T) (i j : 'I_n) : 
   uniq t -> (tnth t i == tnth t j) = (i == j).
 Proof. 
@@ -528,18 +690,17 @@ Lemma mem_tail (T : eqType) (x y : T) s : y \in s -> y \in x :: s.
 Proof. by rewrite inE => ->. Qed.
 Arguments mem_tail [T] x [y s].
 
-
+Lemma in_set_seq (T : finType) (s : seq T) : [set z in s] =i s.
+Proof. by move=> z; rewrite inE. Qed.
+  
+(* inline? *)
 Lemma subset_seqR (T : finType) (A : pred T) (s : seq T) : 
   (A \subset s) = (A \subset [set x in s]).
-Proof. 
-  apply/idP/idP => H; apply: subset_trans H _; apply/subsetP => x; by rewrite inE. 
-Qed.
+Proof. by rewrite (eq_subset_r (in_set_seq _)). Qed.
 
 Lemma subset_seqL (T : finType) (A : pred T) (s : seq T) : 
   (s \subset A) = ([set x in s] \subset A).
-Proof.
-  apply/idP/idP; apply: subset_trans; apply/subsetP => x; by rewrite inE. 
-Qed.
+Proof. by rewrite (eq_subset (in_set_seq _)). Qed.
 
 Lemma mem_catD (T:finType) (x:T) (s1 s2 : seq T) : 
   [disjoint s1 & s2] -> (x \in s1 ++ s2) = (x \in s1) (+) (x \in s2).
@@ -554,6 +715,13 @@ Lemma rpath_sub (T : eqType) (e : rel T) (a : pred T) x p :
 Proof.
   elim: p x => //= b p IH x. rewrite -!andbA => /and4P[H1 H2 H3 H4].
   apply/cons_subset. by split; eauto.
+Qed.
+
+Lemma closed_path_sub (T : eqType) (e : rel T) (x : T) (s : seq T) (p : {pred T}) :
+  (forall z y, e z y -> p z -> p y) -> p x -> path e x s -> {subset s <= p}.
+Proof.
+move => cl_p; elim: s x => //= y s IHs x /cl_p py /andP[e_xy pth_p]. 
+apply/all_cons; split; by [apply: py |apply: IHs (py _ _) pth_p].
 Qed.
 
 Lemma path_rpath (T : eqType) (e : rel T) (A : pred T) x p :
@@ -576,6 +744,12 @@ Proof. elim: s => //= x s IH. case E: (a x) => //=. by rewrite E. Qed.
 Lemma rev_inj (T : Type) : injective (@rev T).
 Proof. apply: (can_inj (g := rev)). exact: revK. Qed.
 
+Lemma last_mem (T : eqType) (x : T) (s : seq T) : 
+  x \in s -> last x s \in s.
+Proof. 
+by elim/last_ind: s => // s y _ _; rewrite last_rcons mem_rcons mem_head.
+Qed.
+
 Lemma last_belast_eq (T : Type) (x : T) p q : 
   last x p = last x q  -> belast x p = belast x q -> p = q.
 Proof. 
@@ -594,6 +768,12 @@ Proof.
   - by apply: H; rewrite inE ?Hx ?Hy.
   - exists (b::p) => /=. suff: e a b by move -> ; subst. by rewrite H ?inE ?eqxx.
 Qed.
+
+Lemma mem_bigcup (T1 T2 : finType) (F : T1 -> {set T2}) (P : pred T1) z y : 
+  P y -> z \in F y -> z \in \bigcup_(x | P x) F x.
+Proof. move => Py zF. by apply/bigcupP; exists y; rewrite ?yA. Qed.
+Arguments mem_bigcup [T1 T2 F P z] y _ _.
+
 
 (** *** Reflexive Transitive Closure *)
 
@@ -670,6 +850,10 @@ move => hom_f; case/connectP => p p1 p2; apply/connectP.
 exists (map f p); by [exact: homo_path p1|rewrite last_map -p2].
 Qed.
 
+Lemma eq_connect_sym (T : finType) (e e' : rel T) : 
+  e =2 e' -> connect_sym e -> connect_sym e'.
+Proof. by move=> eq_e sym_e x y; rewrite -!(eq_connect eq_e). Qed.
+
 Definition sc (T : Type) (e : rel T) := [rel x y | e x y || e y x].
 
 Lemma sc_sym (T : Type) (e : rel T) : symmetric (sc e).
@@ -742,11 +926,18 @@ Proof. apply/setP => x. rewrite -mem_preim !inE. by case: x => [x|]. Qed.
 
 (** *** Set image *)
 
-Lemma inj_imset (aT rT : finType) (f : aT -> rT) (A : {set aT}) (x : aT) :
+(* [imset_f] in mathcomp-1.12 *)
+Lemma inj_imset (aT rT : finType) (f : aT -> rT) (A : {pred aT}) (x : aT) :
   injective f -> (f x \in f @: A) = (x \in A).
 Proof.
-  move=> f_inj; apply/imsetP/idP;
-  [by case=> [y] ? /f_inj-> | by move=> ?; exists x].
+move=> f_inj; apply/imsetP/idP;[by case=> [y] ? /f_inj-> | by move=> ?; exists x].
+Qed.
+
+Lemma imset_inj (aT rT : finType) (f : aT -> rT) : 
+  injective f -> injective (fun A : {set aT} => f @: A).
+Proof.
+move=> inj_f A B eq_AB; apply/setP => x.
+by rewrite -(inj_imset _ _ inj_f) eq_AB inj_imset.
 Qed.
 
 Lemma imset_pre_val (T : finType) (P : pred T) (s : subFinType P) (A : {set T}) :
@@ -847,8 +1038,6 @@ Proof.
 Qed.
 
 (** Extra Morphism declatations *)
-
-Require Import Setoid Morphisms.
 
 Instance ex2_iff_morphism (A : Type) :  
   Proper (pointwise_relation A iff ==> pointwise_relation A iff ==> iff) (@ex2 A).
@@ -954,3 +1143,372 @@ End Preliminaries_dom.
 Arguments in11_in2 [T1 T2 P] A1 A2.
 Arguments maxset_properP {T p D}.
 Arguments minset_properP {T p D}.
+
+
+(** * Extra Preliminaries from Kuratowski/Wagner development *)
+
+#[export] Hint Extern 0 (injective val) => exact val_inj : core.
+#[export] Hint Extern 0 (injective sval) => exact val_inj : core.
+
+Lemma in_setP (T : finType) (p : {pred T}) (x : T) : 
+  reflect (p x) (x \in [set y | p y]).
+Proof. rewrite inE; exact: idP. Qed.
+
+Lemma Sub_imset (T : finType) (P : {pred T}) (s : subFinType P) {A : {set s}} (x : T) (Px : P x) :
+  (Sub x Px \in A) = (x \in val @: A).
+Proof. by rewrite -[X in X \in val @: _](SubK s Px) inj_imset. Qed.
+
+Lemma Sub_map (T : eqType) (P : {pred T}) (s : subType P) {A : seq s} (x : T) (Px : P x) :
+  (Sub x Px \in A) = (x \in map val A).
+Proof. by rewrite -[X in X \in map val _](SubK s Px) mem_map. Qed.
+
+
+Section AltE.
+Variables (T rT : Type) (p : pred T) (x : T) (fT : p x -> rT) (fF : ~~ p x -> rT).
+
+Lemma altT (px : p x) :
+  match boolP (p x) with AltTrue b => fT b | AltFalse b => fF b end = fT px.
+Proof.
+case: {-}_ /boolP => -px'; last by case:notF; rewrite px in px'.
+by rewrite (bool_irrelevance px' px).
+Qed.
+
+Lemma altF (px : ~~ p x) :
+  match boolP (p x) with AltTrue b => fT b | AltFalse b => fF b end = fF px.
+Proof.
+case: {-}_ /boolP => -px'; first by case:notF; rewrite px' in px.
+by rewrite (bool_irrelevance px' px).
+Qed.
+End AltE.
+
+Arguments card_gt0P {T A}.  
+
+(**The following two lemmas are adapted from their [face] instances in [revsnip.v]. *)
+(* TODO: move to preliminaries/mathcomp *)
+Lemma fcard0P (T : finType) (A : pred T) f :
+  injective f -> fclosed f A -> reflect (exists x, x \in A) (0 < fcard f A).
+Proof.
+move => injf clfA.
+apply: (iffP card_gt0P) => [[x /andP[]]|[x xA]]; first by exists x.
+exists (froot f x); rewrite inE roots_root /=; last exact: fconnect_sym.
+by rewrite -(closed_connect clfA (connect_root _ x)).
+Qed.
+
+Lemma fcard1P (T : finType) (A : pred T) f :
+  injective f -> fclosed f A ->
+  reflect (exists2 x, x \in A & exists2 y, y \in A & ~~ fconnect f x y)
+          (1 < fcard f A).
+Proof.
+move=> inj_f clAf; pose cfC := fconnect_sym inj_f.
+apply: (iffP card_gt1P) => [|[x xA [y yA not_xfy]]]. 
+  move => [x] [y] [/andP [/= rfx xA]] /andP[/= rfy yA] xDy.
+  by exists x; try exists y; rewrite // -root_connect // (eqP rfx) (eqP rfy).
+exists (froot f x), (froot f y); rewrite !inE !roots_root ?root_connect //=.
+by split => //; rewrite -(closed_connect clAf (connect_root _ _)).
+Qed.
+
+Lemma index_inj (T : eqType) (s : seq T) : {in s &, injective (index^~ s)}.
+Proof. by move => u v u_s v_s E; rewrite -[u](nth_index u u_s) E nth_index. Qed.
+
+
+Section Closure.
+Variables (T : finType).
+Implicit Types (e : rel T) (a : pred T) (x y : T).
+
+Lemma closureP e a y : 
+  reflect (exists2 x, x \in a & connect e y x) (y \in closure e a).
+Proof. 
+rewrite /closure_mem unfold_in disjoint_sym.
+by apply: (iffP pred0Pn) => [[x] /andP[? ?]|[x]]; exists x.
+Qed.
+
+Lemma closure_connect e a x y : connect e x y -> y \in closure e a -> x \in closure e a.
+Proof. 
+move => e_xy /closureP [z z_a c_yz]; apply/closureP ; exists z => //. 
+exact: connect_trans c_yz. 
+Qed.
+
+Lemma eq_closure e e' a : connect e =2 connect e' -> closure e a =i closure e' a.
+Proof.
+by move => eq_e z; apply/closureP/closureP => -[x ?]; exists x => //; rewrite ?eq_e // -eq_e.
+Qed.
+
+Lemma eq_closure_r e a a': a =i a' -> closure e a =i closure e a'.
+Proof. by move => eq_a y; apply/closureP/closureP => -[x ?]; exists x; rewrite // ?eq_a // -eq_a. Qed.
+
+Lemma eq_fclosure (f f' : T -> T) a : f =1 f' -> fclosure f a =i fclosure f' a.
+Proof. move => eq_f; apply: eq_closure. exact: eq_fconnect. Qed.
+
+Lemma eq_closed (e e' : rel T) (a : {pred T}) : 
+  e =2 e' -> closed e a <-> closed e' a.
+Proof. 
+rewrite /closed_mem => eq_e. 
+by split => cl x y; [rewrite -eq_e|rewrite eq_e]; apply: cl.
+Qed.
+
+Lemma eq_closed_r (e : rel T) (a b : {pred T}) : 
+  a =i b -> closed e a <-> closed e b.
+Proof. 
+by rewrite /closed_mem => ab; split => -cl x y /cl; rewrite !ab.
+Qed.
+
+Lemma predD_closed (e : rel T) (a b : {pred T}) : 
+  connect_sym e -> closed e a -> closed e b -> closed e [predD a & b].
+Proof.
+move=> sym_e cl_a cl_b; apply: intro_closed => // x y xy.
+by rewrite !inE (cl_a _ _ xy) (cl_b _ _ xy).
+Qed.
+
+(* TOTHINK: connect_sym should not be necessary with a good def of closure *)
+Lemma closure1 e x : connect_sym e -> connect e x =i closure e (pred1 x).
+Proof. 
+move => sym_e z; apply/idP/idP => [c_x_z|/closureP [x0] /eqP ->]; last by rewrite sym_e.
+by apply/closureP; exists x; rewrite ?inE // sym_e. 
+Qed.
+
+Lemma closure_pred2 e x y :
+  connect_sym e -> 
+  closure e (pred2 x y) =i [predU closure e (pred1 x) & closure e (pred1 y)].
+Proof.
+move => sym_e z; rewrite !inE /= -!closure1 // !inE.  (* why slow ? *)
+apply/closureP/idP => [[? /pred2P [->|->]]|/orP[]]; rewrite sym_e; try by move->.
+  by exists x; rewrite // !inE eqxx.
+by exists y; rewrite // !inE eqxx.
+Qed.
+
+Lemma codom_id : codom (@id T) =i predT. 
+Proof. by move => x; rewrite -[x]/(id x) codom_f. Qed.
+
+Lemma in_eq_n_comp e e' a : 
+  connect_sym e -> connect_sym e' -> closed e a -> closed e' a ->
+  {in a &, e =2 e'} -> n_comp e a = n_comp e' a.
+Proof. 
+move => sym_e sym_e' cl_e cl_e' eq_e.
+have adj_e : rel_adjunction id e e' a.
+{ apply: strict_adjunction => //=. apply/subsetP => z _; exact: codom_id.
+  move => u v u_a. rewrite inE negbK /= in u_a. 
+  apply/idP/idP => uv; first by rewrite -eq_e // -(cl_e u v).
+  by rewrite eq_e // -(cl_e' u v). }
+rewrite [in RHS](eq_n_comp_r (_ : a =i [preim id of a])) //. 
+exact: adjunction_n_comp. 
+Qed.
+
+End Closure.
+Arguments eq_closed [T e e' a].
+Arguments eq_closed_r [T e a b].
+
+Section order.
+Variables (T : finType) (f : T -> T).
+
+Lemma before_findex x z m : 
+  fconnect f x z -> m < findex f x z -> iter m f x != z.
+Proof.
+elim: m x z => [x z|n IHn x z xCz nz]; first by rewrite lt0n findex_eq0.
+have xDz : z != x by apply: contraTneq nz => ->; rewrite findex0.
+rewrite iterSr IHn -1?ltnS -?fconnect_findex //.
+by rewrite fconnect_eqVf eq_sym (negbTE xDz) in xCz.
+Qed.
+
+Lemma order_le_looping m z : looping f z m -> order f z <= m.
+Proof. 
+apply: contraTT; rewrite -ltnNge -looping_uniq => m_lt_o.
+rewrite -(take_traject _ _ m_lt_o); exact: take_uniq (orbit_uniq _ _).
+Qed.
+
+Lemma order_le_fix m z : iter m.+1 f z = z -> order f z <= m.+1.
+Proof.  
+move=> fix_z. apply: order_le_looping.
+by rewrite /looping fix_z trajectS mem_head.
+Qed.
+
+Lemma iter_looping m z y :
+  (forall n, n < m -> iter n f z != y) -> looping f z m -> ~~ fconnect f z y.
+Proof.
+move => not_y ?; rewrite fconnect_orbit; apply/trajectP => -[k k_lt_o].
+apply/eqP; rewrite eq_sym not_y //. 
+exact: leq_trans k_lt_o (order_le_looping _).
+Qed.
+
+Lemma findex_finv z : findex f z (finv f z) = (order f z).-1.
+Proof. by rewrite findex_iter ?orderSpred. Qed.
+
+Lemma index_orbit (x : T) :
+  index x (orbit f x) = 0.
+Proof. by rewrite /orbit -orderSpred /= eqxx. Qed.
+
+Lemma arc_orbit (x y : T) : 
+  fconnect f x y -> arc (orbit f x) x y = traject f x (findex f x y).
+Proof.
+move=> conn_xy; rewrite /arc index_orbit rot0 /findex; set i := index y _.
+suff I : i <= order f x by rewrite -(take_traject _ _ I).
+by apply: ltnW; rewrite -size_orbit index_mem -fconnect_orbit.
+Qed.
+
+Lemma findex_bound (x y : T) n : iter n f x = y -> findex f x y <= n.
+Proof. 
+move => iter_n; have f_xy: fconnect f x y by rewrite -iter_n fconnect_iter.
+by apply: contra_eqT iter_n; rewrite -ltnNge; apply: before_findex.
+Qed.
+
+(** [injective f] could be weakened to [fcycle f (orbit f x)] *)
+Lemma findex_f (x y : T) : injective f -> fconnect f x y -> 
+  findex f (f x) (f y) = findex f x y.
+Proof.
+move=> inj_f conn_xy; apply/eqP; rewrite eqn_leq; apply/andP;split.
+  by apply: findex_bound; rewrite -iterSr iterS iter_findex.
+apply: findex_bound; rewrite -[iter _ _ _](finv_f inj_f) -iterS iterSr.
+by rewrite iter_findex ?finv_f // -same_fconnect1 -?same_fconnect1_r.
+Qed.
+
+Lemma fconnect_findex_r (x y : T) : 
+  injective f -> fconnect f x y -> y != x -> 
+  findex f x y = (findex f x (finv f y)).+1.
+Proof. 
+move=> inj_f con_xy yDx. 
+by rewrite -[in RHS]findex_f 1?same_fconnect1_r ?f_finv // fconnect_findex .
+Qed.
+
+Lemma orbit_prefix n x :
+  n <= order f x -> orbit f x = traject f x n ++ drop n (orbit f x).
+Proof.
+move => le_n_ox.
+by rewrite /orbit -(subnKC le_n_ox) trajectD drop_size_cat // size_traject.
+Qed.
+
+(** generalizes [orbit_id] *)
+Lemma orbit_fix x : f x = x -> orbit f x = [:: x].
+Proof. 
+move => fx; rewrite /orbit (_ : order f x = 1) //.
+by apply/eqP; rewrite eqn_leq order_gt0 andbT; apply: order_le_fix.
+Qed.
+
+Lemma order_f (inj_f : injective f) x: 
+  order f (f x) = order f x.
+Proof. by apply/(orbitPcycle 1 2); rewrite /= inE -same_fconnect1. Qed.
+
+Lemma orbit_rot1 (inj_f : injective f) x : orbit f (f x) = rot 1 (orbit f x).
+Proof.
+have [fx_x|fxNx] := eqVneq (f x) x; first by rewrite fx_x orbit_fix.
+suff S : index (f x) (orbit f x) = 1.
+  rewrite (orbitE (cycle_orbit inj_f x)) ?S //. 
+  by rewrite -fconnect_orbit -same_fconnect1_r.
+rewrite /orbit -orderSpred /= eq_sym (negPf fxNx). 
+by case: (_.-1) => //= n; rewrite eqxx.
+Qed.
+
+Lemma orbit_rot_iter n (inj_f : injective f) x o :
+  orbit f x = o -> orbit f (iter n f x) = iter n (rot 1) o.
+Proof. by move <-; elim: n => // n IHn; rewrite !iterS -IHn orbit_rot1. Qed.
+
+End order.
+
+Arguments eq_closure_r [T e a a'].
+
+Lemma forall_all (T : finType) (p : {pred T}) : [forall x, p x] = all p (enum T).
+Proof. apply/forallP/allP => [|H x]; by [firstorder|apply/H/mem_enum]. Qed.
+
+Lemma exists_has (T : finType) (p : {pred T}) : [exists x, p x] = has p (enum T).
+Proof. by rewrite -[LHS]negbK negb_exists forall_all all_predC negbK. Qed.
+
+Lemma n_compD (T : finType) (a b : {pred T}) e : 
+  n_comp e a = n_comp e [predI a & b] + n_comp e [predD a & b].
+Proof.
+rewrite -[LHS](cardID b).
+by congr (_ + _); apply: eq_card => x; rewrite !inE; case: (roots _ _).
+Qed.
+
+Arguments n_compD [T a] b.
+
+Lemma n_comp0 (T : finType) (e : rel T) (a : {pred T}) : 
+  a =i pred0 -> n_comp e a = 0.
+Proof. 
+by move=> a0; rewrite (eq_n_comp_r a0); apply: eq_card0 => x; rewrite !inE andbF.
+Qed.
+
+Lemma set_inP (T : finType) (A : {pred T}) (p : pred T) x :
+  reflect (x \in A /\ p x) (x \in [set x in A | p x]).
+Proof. rewrite !inE; exact: andP. Qed.
+
+Section RootPartition.
+Variables (T : finType) (e : rel T) (A : {set T}).
+Hypothesis sym_e : connect_sym e.
+Hypothesis closed_A : closed e A.
+
+Lemma closed_root x : (root e x \in A) = (x \in A).
+Proof.
+symmetry; exact: closed_connect closed_A _ _ (connect_root _ _). 
+Qed.
+
+Let block x := [set y in connect e x].
+Definition root_partition := [set block x | x in A & x \in roots e].
+
+Lemma root_partitionE : 
+  root_partition = equivalence_partition (connect e) A.
+Proof.
+apply/setP => B; apply/imsetP/imsetP => -[x Hx ->].
+  move: Hx => /set_inP[x_A root_x]; exists x => //; apply/setP => y.
+  by rewrite !inE andb_idl // => xy; rewrite -(closed_connect closed_A xy).
+exists (root e x); first by rewrite !inE closed_root Hx roots_root.
+apply/setP => y; rewrite !inE andb_idl => [|xy]. 
+  apply: same_connect => //; exact: connect_root.
+by rewrite -(closed_connect closed_A xy).
+Qed. 
+
+Lemma connect_equivalence : equivalence_rel (connect e).
+Proof. 
+by rewrite equivalence_relP; split; by [apply: connect0|apply: same_connect].
+Qed.
+
+Lemma root_partitionP : partition root_partition A.
+Proof. 
+rewrite root_partitionE equivalence_partitionP //.
+by apply:in3W; apply: connect_equivalence. 
+Qed.
+
+Let rpP := root_partitionP.
+
+Lemma sum_roots : #|A| = \sum_(x in roots e | x \in A) #|connect e x|.
+Proof.
+under [RHS]eq_bigl => ? do rewrite andbC.
+rewrite (card_partition rpP) (set_partition_big_cond _ rpP) /=.
+apply: eq_bigr => B /imsetP [x]; rewrite inE => /andP[x_A root_x] ->.
+rewrite (big_pred1 x) ?cardsE // => y; rewrite !inE.
+apply/andP/eqP => [[xy root_y]|->//]. 
+by rewrite -(eqP root_y) -(rootP sym_e xy) (eqP root_x).
+Qed.
+
+Lemma n_comp_partition : n_comp e A = #|equivalence_partition (connect e) A|.
+Proof. 
+rewrite -root_partitionE.
+rewrite card_in_imset; first by apply: eq_card => z; rewrite !inE andbC.
+move => x y /set_inP [x_A root_x] /set_inP [y_A root_y] /setP /(_ y).
+rewrite !inE connect0 -{2}[x](eqP root_x) -{2}[y](eqP root_y) => xy.
+exact/rootP.
+Qed.
+
+End RootPartition.
+
+Lemma closedT (T : finType) (e : rel T) : closed e [set: T].
+Proof. by move=> *; rewrite !inE. Qed.
+
+Lemma sum_rootsT (T : finType) (e : rel T) : 
+  connect_sym e -> #|T| = \sum_(x in roots e) #|connect e x|.
+Proof.
+move=> sym_e; rewrite -cardsT (sum_roots sym_e); last exact: closedT.
+by under eq_bigl => ? do rewrite !inE andbT.
+Qed.
+
+Lemma sum_roots_order (T : finType) (f : T -> T) (inj_f : injective f) :
+  #|T| = \sum_(x in froots f) order f x.
+Proof. exact/sum_rootsT/fconnect_sym. Qed.
+
+
+
+Lemma sub_in_connect (T : finType) (e e' : rel T) (x : T) : 
+  (forall y, connect e x y -> e y =1 e' y) -> forall y, connect e x y -> connect e' x y.
+Proof.
+move => H y /connectP [p]. elim/last_ind : p y => [y _ -> //|p z IHp y].
+rewrite rcons_path last_rcons => /andP[pth_p ez -> {y}].
+rewrite H in ez; last by apply/connectP; exists p.
+apply: connect_trans (connect1 ez). exact: IHp.
+Qed.

--- a/theories/sgraph.v
+++ b/theories/sgraph.v
@@ -22,8 +22,8 @@ Coercion digraph_of : sgraph >-> diGraph.
 (** The notation [x -- y] is now inherited *)
 (* Notation "x -- y" := (sedge x y) (at level 30). *)
 
-Definition sg_sym (G : sgraph) : symmetric (@edge_rel G). exact: sg_sym'. Qed.
-Definition sg_irrefl (G : sgraph) : irreflexive (@edge_rel G). exact: sg_irrefl'. Qed.
+Definition sg_sym (G : sgraph) : @symmetric G (--). exact: sg_sym'. Qed.
+Definition sg_irrefl (G : sgraph) : @irreflexive G (--). exact: sg_irrefl'. Qed.
 
 Definition sgP := (sg_sym,sg_irrefl).
 Prenex Implicits sedge.
@@ -31,7 +31,7 @@ Prenex Implicits sedge.
 Lemma sg_edgeNeq (G : sgraph) (x y : G) : x -- y -> (x == y = false).
 Proof. apply: contraTF => /eqP ->. by rewrite sg_irrefl. Qed.
 
-Lemma sconnect_sym (G : sgraph) : connect_sym (@sedge G).
+Lemma sconnect_sym (G : sgraph) : @connect_sym G (--). 
 Proof. exact/connect_symI/sg_sym. Qed.
 
 Lemma sedge_equiv (G : sgraph) : 
@@ -39,19 +39,19 @@ Lemma sedge_equiv (G : sgraph) :
 Proof.  apply: equivalence_rel_of_sym. exact: sg_sym. Qed.
 
 Lemma symmetric_restrict_sedge (G : sgraph) (A : pred G) :
-  symmetric (restrict A sedge).
+  symmetric (restrict A (--)).
 Proof. apply: restrict_sym. exact: sg_sym. Qed.
 
 Lemma srestrict_sym (G : sgraph) (A : pred G) :
-  connect_sym (restrict A sedge).
+  connect_sym (restrict A (--)).
 Proof. exact/connect_symI/symmetric_restrict_sedge. Qed.
 
 Lemma sedge_in_equiv (G : sgraph) (A : {set G}) :
-  equivalence_rel (connect (restrict A sedge)).
+  equivalence_rel (connect (restrict A (--))).
 Proof. exact/equivalence_rel_of_sym/symmetric_restrict_sedge. Qed.
 
 Lemma sedge_equiv_in (G : sgraph) (A : {set G}) :
-  {in A & &, equivalence_rel (connect (restrict A sedge))}.
+  {in A & &, equivalence_rel (connect (restrict A (--)))}.
 Proof. exact: in3W (sedge_in_equiv A). Qed.
 
 Declare Scope sgraph_scope.
@@ -205,9 +205,9 @@ Lemma last_rev_belast x y p :
 Proof. case: p => //= a p _. by rewrite /srev rev_cons last_rcons. Qed.
 
 Lemma path_srev x p : 
-  path sedge x p = path sedge (last x p) (srev x p).
+  path (--) x p = path (--) (last x p) (srev x p).
 Proof. 
-  rewrite rev_path [in RHS](eq_path (e' := sedge)) //. 
+  rewrite rev_path [in RHS](eq_path (e' := (--))) //. 
   move => {x} x y. exact: sg_sym. 
 Qed.
 
@@ -257,7 +257,7 @@ End SimplePaths.
 
 Lemma upathPR (G : sgraph) (x y : G) A :
   reflect (exists p : seq G, @upath (srestrict A) x y p)
-          (connect (restrict A sedge) x y).
+          (connect (restrict A (--)) x y).
 Proof. exact: (@upathP (srestrict A)). Qed.
 
 (* TOTHINK: is this the best way to transfer path from induced subgraphs *)
@@ -590,21 +590,21 @@ Proof.
 Qed.
 
 Lemma connectedTE (G : sgraph) : 
-  connected [set: G] -> forall x y : G, connect sedge x y. 
+  connected [set: G] -> forall x y : G, connect (--) x y. 
 Proof. 
   move => A x y. move: (A x y). 
   rewrite !inE !restrictE; first by apply. by move => ?; rewrite !inE.
 Qed.
 
 Lemma connectedTI (G : sgraph) : 
-  (forall x y : G, connect sedge x y) -> connected [set: G].
+  (forall x y : G, connect (--) x y) -> connected [set: G].
 Proof. move => H x y _ _. rewrite restrictE // => z. by rewrite inE. Qed.
 
 Lemma connected_restrict (G : sgraph) (A : pred G) x : 
-  connected [set y | connect (restrict A sedge) x y].
+  connected [set y | connect (restrict A (--)) x y].
 Proof.
   move => u v. rewrite !inE => Hu Hv. move defP : (mem _) => P.
-  wlog suff W: u Hu / connect (restrict P sedge) x u.
+  wlog suff W: u Hu / connect (restrict P (--)) x u.
   { apply: connect_trans (W _ Hv). rewrite srestrict_sym. exact: W. }
   case: (altP (x =P u)) => [-> //|xDu].
   case/connect_irredRP : Hu => // p Ip Ap.
@@ -615,15 +615,15 @@ Proof.
 Qed.
 
 Lemma connect_range (G : sgraph) (A : pred G) x : x \in A -> 
-  [set y | connect (restrict A sedge) x y] = 
-  [set y in A | connect (restrict A sedge) x y].
+  [set y | connect (restrict A (--)) x y] = 
+  [set y in A | connect (restrict A (--)) x y].
 Proof. 
   move => inA. apply/setP => z. rewrite !inE srestrict_sym.
   apply/idP/andP => [|[//]]. by case/connect_restrict_case => [->|[]].
 Qed.
 
 Lemma connected_restrict_in (G : sgraph) (A : pred G) x : x \in A -> 
-  connected [set y in A | connect (restrict A sedge) x y].
+  connected [set y in A | connect (restrict A (--)) x y].
 Proof. move => inA. rewrite -connect_range //. exact: connected_restrict. Qed.
 
 (* NOTE: This could be generalized to sets and their images *)
@@ -655,7 +655,7 @@ Proof.
 Qed.
 
 Lemma connected_center (G:sgraph) x (S : {set G}) :
-  {in S, forall y, connect (restrict S sedge) x y} -> x \in S ->
+  {in S, forall y, connect (restrict S (--)) x y} -> x \in S ->
   connected S.
 Proof.
   move => H inS y z Hy Hz. apply: connect_trans (H _ Hz).
@@ -748,7 +748,7 @@ Qed.
 (** *** Connected components *)
 
 Definition components (G : sgraph) (H : {set G}) : {set {set G}} :=
-  equivalence_partition (connect (restrict H sedge)) H.
+  equivalence_partition (connect (restrict H (--))) H.
 
 Lemma partition_components (G : sgraph) (H : {set G}) :
   partition (components H) H.
@@ -805,7 +805,7 @@ Proof.
   have CH: {subset C <= H}. 
   { move => z Hz. rewrite -compU. apply/bigcupP; by exists C. } 
   move/CH : (in_C) => in_H. 
-  suff -> : C = [set y in H | connect (restrict H sedge) x y].
+  suff -> : C = [set y in H | connect (restrict H (--)) x y].
   { exact: connected_restrict_in. }
   apply/setP => y. rewrite inE. case: (boolP (y \in H)) => /= [y_in_H|y_notin_H].
   - by rewrite -PEQ // ?(def_pblock _ C_comp).
@@ -841,10 +841,10 @@ Proof.
   move=> ? C_comp G_conn VC_conn.
   case/and3P: (partition_components V) => /eqP compU compI _.
   have sub : C \subset V by rewrite -compU; exact: bigcup_sup.
-  have subr : subrel (connect (restrict (~: V) sedge))
-                     (connect (restrict (~: C) sedge))
+  have subr : subrel (connect (restrict (~: V) (--)))
+                     (connect (restrict (~: C) (--)))
     by apply: connect_mono; apply: restrict_mono; apply/subsetP; rewrite setCS.
-  suff to_x0 (x : G) : x \in ~: C -> connect (restrict (~: C) sedge) x x0.
+  suff to_x0 (x : G) : x \in ~: C -> connect (restrict (~: C) (--)) x x0.
   { move=> x y /to_x0 x_x0 /to_x0. rewrite srestrict_sym. exact: connect_trans. }
   rewrite inE => xNC. wlog x_V : x xNC / x \in V.
   { move=> Hyp. case: (boolP (x \in V)); first exact: Hyp. move=> xNV.
@@ -999,7 +999,7 @@ Proof.
 Qed.
 
 Definition connectedb S := 
-  [forall x in S, forall y in S, connect (restrict S sedge) x y].
+  [forall x in S, forall y in S, connect (restrict S (--)) x y].
 
 Lemma connectedP S : reflect (connected S) (connectedb S).
 Proof. 

--- a/theories/skeleton.v
+++ b/theories/skeleton.v
@@ -555,7 +555,7 @@ Qed.
 (* Is this the most general type? *)
 Lemma card_val (T : finType) (P : pred T) (s : subFinType P) (A : pred s) : 
   #|val @: A| = #|A|.
-Proof. rewrite card_imset //. exact: val_inj. Qed.
+Proof. by rewrite card_imset. Qed.
 
 (* lifting connectedness from the skeleton *)
 Lemma connected_skeleton' (G : graph) V E (con : @consistent _ _ G V E) :

--- a/theories/skeleton.v
+++ b/theories/skeleton.v
@@ -57,7 +57,7 @@ Definition skeleton (G : graph) :=
 Lemma skelP (G : graph) (P : G -> G -> Prop) : 
   Symmetric P -> 
   (forall e : edge G, source e != target e -> P (source e) (target e)) ->
-  (forall x y : G,  sk_rel x y -> P x y).
+  (forall x y : skeleton G, x -- y -> P x y).
 Proof. 
   move => S H x y. case/andP=> xNy. case/existsP=> e He. move: He xNy. rewrite !inE.
   case/orP=> /andP[/eqP<- /eqP<-]; last rewrite eq_sym; move=> /H//. exact: S.
@@ -97,10 +97,10 @@ Proof.
 Qed.
 
 
-Lemma hom_skel (G1 G2 : graph) (h: iso G1 G2) :
-  forall x y, @edge_rel (skeleton G1) x y -> @edge_rel (skeleton G2) (h x) (h y).
+Lemma hom_skel (G1 G2 : graph) (h: iso G1 G2) : 
+  {homo h : x y / (x : skeleton _) -- y}.
 Proof.
-  apply skelP. 
+  apply: skelP.
   - move => x y. by rewrite sgP.
   - move => e He. rewrite /edge_rel/=/sk_rel. 
     rewrite bij_eq ?He //=. apply/existsP; exists (h.e e). 
@@ -245,7 +245,7 @@ Proof.
   apply: connect_sub x y. move=> /=. apply skelP.
   - by move=> x y; rewrite connect_symI //; exact: sk_rel_sym (remove_edges E).
   - move=> e sNt. case: (boolP (e \in E)) => [/E_conn//|He].
-    apply: connect1. rewrite /sk_rel/= sNt /=.
+    apply: connect1. rewrite /edge_rel/=/sk_rel sNt /=.
     by apply/existsP; exists (Sub e He); rewrite !inE !eqxx.
 Qed.
 

--- a/theories/smerge.v
+++ b/theories/smerge.v
@@ -1,0 +1,700 @@
+From mathcomp Require Import all_ssreflect.
+Require Import edone preliminaries digraph sgraph connectivity minor treewidth arc.
+Require Import set_tac.
+
+(* TOTHINK : arc is only included for the [path0] definition *)
+
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
+Canonical edge_app_pred (G : diGraph) (x : G) := ApplicativePred (edge_rel x).
+Canonical sedge_app_pred (G : sgraph) (x : G) := ApplicativePred (sedge x).
+
+(** If [S] is a smallest separator, then every (maximal) component of G-S 
+    can be seen as one part of a proper separation *)
+Lemma component_separation (G : sgraph) (A S : {set G}) x : 
+  smallest vseparator S -> 
+  x \in A -> [disjoint A & S] -> connected A -> {in A & ~: A, forall x y, x--y -> y \in S} ->
+  proper_separation (A :|: S) (~: A :|: S).
+Proof.
+move=> [sepS minS] x_A dis_A_S conA compA. 
+case: sepS => [u[v sep_uv]].
+have Huv : (u \notin A) || (v \notin A).
+{ apply: contraTT (dis_A_S); rewrite negb_or !negbK => /andP [u_A v_A].
+  have uDv := separatesNeq sep_uv.
+  have/(connect_irredRP uDv) [p Ip /subsetP subA] := conA _ _ u_A v_A.
+  case: sep_uv => uNS vNS /(_ p) [z /subA ? ?]. by apply/pred0Pn; exists z. }
+wlog uNA : u v sep_uv {Huv} / u \notin A => [W|].
+{ case/orP: Huv; apply: W;[|rewrite separates_sym]; exact: sep_uv. }
+case: (sep_uv) => uNS vNS sepS.
+split; first split.
+- by move => z; rewrite !inE; case: (z \in A).
+- move => x1 x2. rewrite !inE !negb_or !negbK => /andP [x1_A x1NS] /andP [x2_A]. 
+  by apply: contraNF => /compA; apply; rewrite ?inE.
+- by exists x,u; rewrite !inE x_A (disjointFr dis_A_S) //= negb_or uNA uNS.
+Qed.
+
+
+(** * Merging Vertices  *)
+
+(** The definition of [smerge2 G x y] is simply to remove [y] and
+attach all edges of [y] to [x], regardless of whether [x -- y] holds
+or not. We use both variants. Edge-constraction drives the main
+argument for the 3-connected case of Wagner's theorem. On the other
+hand, vertex merging is used extensively when extending the result
+from 3-connected graphs to general graphs *)
+
+Section SMerge2.
+Variables (G : sgraph) (x y : G).
+
+Definition smerge2_vertex := { z : G | z != y }.
+Definition smerge2_rel := 
+  [rel u v : smerge2_vertex | 
+   if (val u == x) && (val v != x) then val v -- x || val v -- y else 
+   if (val v == x) && (val u != x) then val u -- x || val u -- y else 
+   val u -- val v].
+
+Lemma smerge2_irrefl : irreflexive smerge2_rel. 
+Proof. by move => u /=; case: (sval u == x); rewrite /= ?andbF ?sgP. Qed.
+
+Lemma smerge2_sym : symmetric smerge2_rel.
+Proof. 
+move => u v /=; (case: (altP (sval u =P x)); case: (altP (sval v =P x)) => //=) => [-> -> //|].
+by rewrite sgP.
+Qed.
+
+Definition smerge2 := SGraph smerge2_sym smerge2_irrefl.
+
+Lemma smerge2_edge (u v : smerge2) : val u -- val v -> u -- v.
+Proof.
+move=> val_uv; rewrite /edge_rel/=. 
+case: (boolP (_ && _)) => [/andP[/eqP<- _]|_]; first by rewrite sgP val_uv.
+case: (boolP (_ && _)) => [/andP[/eqP<- _]|_]; by rewrite val_uv.
+Qed.
+
+Lemma smerge2_minor : x -- y -> minor G smerge2.
+Proof. 
+move => xy.
+pose phi (z : smerge2) : {set G} := if val z == x then [set x;y] else [set val z].
+suff: minor_rmap phi by apply: minor_of_rmap.
+split.
+- move => z; rewrite /phi; case: ifP => _; solve [exact: set10|exact: setU1_neq].
+- move => z; rewrite /phi; case: ifP => _; solve [exact: connected1|exact: connected2].
+- move => z1 z2 z1Dz2; rewrite /phi. 
+  case: (eqVneq x (val z1)) => [->|xDz1]. 
+  + rewrite eq_sym val_eqE (negbTE z1Dz2) disjoint_sym disjoints1 !inE negb_or.
+    by rewrite eq_sym val_eqE (negbTE z1Dz2) (valP z2).
+  + case: (eqVneq x (val z2)) => [->|xDz2]; rewrite disjoints1 !inE ?negb_or ?val_eqE //.
+    by rewrite z1Dz2 (valP z1).
+- have H z u v : sval u = x -> sval v != x -> sval v -- z -> z \in [set x; y] -> neighbor (phi u) (phi v).
+  { move => eq_u eq_v v_z Hz. apply/neighborP; exists z; exists (sval v).  
+    by rewrite /phi [val u]eq_u eqxx (negbTE eq_v) sgP v_z Hz inE eqxx. }
+  move => u v. rewrite /edge_rel/=. 
+  case: (altP (sval u =P x)); case: (altP (sval v =P x)) => //=.
+  + move => -> ->. by rewrite sgP.
+  + move => eq_v eq_u. by case/orP => ?; [apply: (H x)|apply: (H y)]; rewrite //= !inE !eqxx.
+  + move => eq_v eq_u. rewrite neighborC. 
+    by case/orP => ?; [apply: (H x)|apply: (H y)]; rewrite //= !inE !eqxx.
+  + move => eq_v eq_u u_v. apply/neighborP; exists (val u); exists (val v).
+    by rewrite /phi /= (negbTE eq_v) (negbTE eq_u) 2!sgP !inE !eqxx u_v.
+Qed.
+
+End SMerge2.
+Arguments smerge2 : clear implicits.
+
+Lemma card_smerge2 (G : sgraph) (x y : G) : 
+  #|smerge2 G x y|.+1 = #|G|.
+Proof. 
+rewrite card_sig [RHS](cardD1 y) add1n; congr (_.+1).
+by apply: eq_card => z; rewrite !inE.
+Qed.
+
+Lemma smerge2_val_edge (G : sgraph) (x y : G) (u v : smerge2 G x y) : 
+  val u != x -> val v != x -> val u -- val v = u -- v.
+Proof.
+move: u v => [u uDy] [v vDy] /= uDx vDx.
+by rewrite [RHS]/edge_rel/= (negbTE uDx) (negbTE vDx).
+Qed.
+
+(* not used, but it probably should by *)
+Lemma smerge2_neighbor (G : sgraph) (x y : G) (xDy : x != y) : 
+  val @: N(Sub x xDy : smerge2 G x y) = (N(x) :|: N(y)) :\: [set x;y]. 
+Proof.
+apply/setP => z; rewrite !inE; apply/imsetP/andP => [[z0 Hz0 ->]|[]].
+  move: Hz0. rewrite !inE negb_or (valP z0) /edge_rel/= eqxx andbF /=.
+  case: (eqVneq (sval z0) x) => /= [<-|]; by rewrite ?sg_irrefl ?[sval _ -- _]sg_sym.
+rewrite negb_or => /andP [zDx zDy]; exists (Sub z zDy) => //. 
+by rewrite inE /edge_rel/= eqxx andbF /= ![z -- _]sg_sym zDx.
+Qed.
+
+Lemma smerge2_path0 (G : sgraph) (x y : G) (s : seq (smerge2 G x y)) : 
+  let s0 := [seq val x | x <- s] in path0 (--) s -> x \notin s0 -> path0 (--) s0.
+Proof.
+hnf; case: s => // u s; elim: s u => // v s /= IHs u /= /andP[uv pth_s].
+rewrite !inE !negb_or => /and3P[xDu xDv xNs]. 
+by rewrite smerge2_val_edge ?[_ == x]eq_sym // uv /= IHs // inE (negPf xDv).
+Qed.
+
+Lemma smerge2_ucycle (G : sgraph) (x y : G) (s : seq (smerge2 G x y)) : 
+  let s0 := [seq val x | x <- s] in
+  ucycle (--) s -> x \notin s0 -> ucycle (--) s0.
+Proof.
+hnf; case: s => // z s; rewrite /ucycle/cycle/= => /and3P[pth_s zNs uniq_s xNs].
+rewrite map_inj_uniq ?uniq_s ?andbT; last exact: val_inj.
+rewrite mem_map // zNs andbT -map_rcons.
+apply: (@smerge2_path0 G x y (z::rcons s z)) => //=.
+by move: xNs; rewrite !inE map_rcons mem_rcons inE !negb_or andbA andbb.
+Qed.
+
+Lemma smerge2edgeD (G : sgraph) (x y : G) (u v : smerge2 G x y) : 
+  ~~ x -- y -> 
+  u -- v = [|| val u -- val v, (val u == x) && val v -- y | (val v == x) && val u -- y].
+Proof.
+move => n_xy; rewrite [LHS]/edge_rel/= -![sval _]/(val _).
+case: (eqVneq (val u) x) => [->|uDx]; case: (eqVneq (val v) x) => [->|vDx] //=.
+- by rewrite sg_irrefl (negbTE n_xy).
+- by rewrite orbF ![_ -- val _]sgP.
+Qed.
+
+Lemma smerge2edgeL (G : sgraph) (x y : G) (u v : smerge2 G x y) : 
+  ~~ x -- y -> val u == x -> val v -- y -> u -- v.
+Proof. 
+move=> xNy uEx vy. rewrite /edge_rel/= -![sval _]/(val _) uEx andbF /= vy orbT.
+case: (eqVneq (val v) x) => // E. by rewrite -E vy in xNy.
+Qed.
+
+(** wlog reasoning for edges of [smerge2 G x y] when the conclusion is symmetric *)
+Lemma smerge2Ecase (G : sgraph) (x y : G) (G' := smerge2 G x y) (P : G' -> G' -> Prop) :
+  ~~ x -- y -> (forall u v, P u v <-> P v u) -> 
+  (forall u v, val u -- val v -> P u v) -> (forall u v, (val u == x) && val v -- y -> P u v) ->
+  forall u v, u -- v -> P u v.
+Proof.
+move=> xNy Psym P1 P2 u v. rewrite smerge2edgeD //; case/or3P => //. exact: P1. exact: P2.
+rewrite Psym. exact: P2.
+Qed.
+
+
+Lemma smerge2_separator (G : sgraph) (x y : G) (S : {set smerge2 G x y}) :
+  vseparator S -> vseparator (y |: val @: S).
+Proof.
+move => [u[v [uNS vNS sep_uv]]]. 
+exists (val u),(val v); split => [||p].
+- rewrite !inE (negbTE (valP u)) /= inj_imset //; exact: val_inj.
+- rewrite !inE (negbTE (valP v)) /= inj_imset //; exact: val_inj.
+- have [|yNp] := boolP (y \in p); first by exists y => //; rewrite !inE eqxx.
+  have [|//||q eq_q _] := lift_Path (p' := p).
+  + exact: smerge2_edge.
+  + move => z z_p. have zDy : z != y by apply: contraTneq z_p => ->.
+    by apply/mapP; exists (Sub z zDy) => //; rewrite mem_enum.
+  + have [z z_q z_S] := sep_uv q; exists (val z); last by rewrite !inE inj_imset ?z_S.
+    by rewrite mem_path -eq_q mem_map.
+Qed. 
+
+Lemma smerge_konnected k (G : sgraph) (x y : G) : 
+  x -- y -> k.+1.-connected G -> k.-connected (smerge2 G x y).
+Proof.
+move=> xy [lG vsG]; split => [|S sepS]; first by rewrite -ltnS card_smerge2.
+have/vsG := smerge2_separator sepS.
+rewrite cardsU1 card_imset // [_ \notin _](_ : _ = true) //.
+by apply: contraTN isT => /imsetP -[[z zDy _ /= E]]; rewrite -E eqxx in zDy.
+Qed.
+
+(** ** Edge Contraction in 3-connected graphs *)
+
+
+(** Any separator of [smerge2 G x y] that does not contain [x] can be
+lifted to a separator in of [G] *)
+Lemma separator_from_smerge2 (G : sgraph) (x y : G) (xDy : x != y) 
+  (x' := Sub x xDy) (S : {set smerge2 G x y}) :
+  vseparator S -> x' \notin S -> vseparator (val @: S).
+Proof.
+move=> /vseparator_separation [V1 [V2 [psepV def_S]]] xNS.
+wlog x_V1 : V1 V2 psepV def_S / x' \notin V2 => [W|].
+{ case: (boolP (x' \in V2)) => [x_V2|]; last exact: (W V1 V2).
+  apply: (W V2 V1); rewrite 1?proper_separation_symmetry 1?setIC //.
+  case: psepV => sepV _. apply: contraNN xNS => x_V1. by rewrite def_S inE x_V1 x_V2. }
+suff: proper_separation (y |: val @: V1) (val @: V2).
+{ move/proper_vseparator. 
+  suff -> : (y |: val @: V1) :&: (val @: V2) = val @: S by [].
+  apply/setP => u; rewrite def_S inE imsetI ?inE; last exact: (in2W val_inj).
+  rewrite (@andb_id2r _ _ (u \in val @: V1)) // => /imsetP [u0 _ ->].
+  by rewrite (negbTE (valP u0)). }
+split; first split.
+- move => u. case: (eqVneq u y) => [->|uDy]; rewrite !inE ?eqxx ?(negbTE uDy) //=.
+  case: psepV => sepV _. have := sepV.1 (Sub u uDy). 
+  by rewrite Sub_imset imsetU inE.  
+- move => u v; rewrite !inE negb_or => u_V1 /andP [vDy v_V2].
+  case: psepV => sepV _.
+  have v'_V2 : (Sub v vDy) \notin V1.
+  { by apply: contraNN v_V2 => H; apply/imsetP; exists (Sub v vDy). }
+  have vDx : v != x. 
+  { apply: contraNneq x_V1 => ?; subst v. apply: sep_inR sepV _. 
+    by rewrite /x' (bool_irrelevance xDy vDy). }
+  case: (eqVneq u y) => [?|uDy]; first subst u. 
+  + apply: contraFF (sepV.2 _ _ x_V1 v'_V2) => yv. 
+    by rewrite /edge_rel/= eqxx vDx [v -- y]sgP yv orbT.
+  + have u'_V1 : (Sub u uDy) \notin V2.
+  { by apply: contraNN u_V1 => H; apply/imsetP; exists (Sub u uDy). }
+    apply: contraFF (sepV.2 _ _ u'_V1 v'_V2) => uv. 
+  rewrite /edge_rel/=. rewrite (negbTE vDx) /= andbT.
+  by case: (eqVneq u x) => [<-|//]; rewrite [v -- u]sgP uv.
+- case: psepV => _ [u [v [u_V1 v_V2]]]. 
+  exists (val u),(val v). by rewrite !(inE,inj_imset) // negb_or (valP v).
+Qed.
+
+Lemma edge_separator (G : sgraph) (x y : G) : 
+  4 < #|G| -> 3.-connected G -> x -- y -> ~ 3.-connected (smerge2 G x y) -> 
+  exists z, vseparatorb [set x;y;z].
+Proof.
+move => largeG conn3G xy nconn3Gxy. 
+have conn2Gxy : 2.-connected (smerge2 G x y) by apply: smerge_konnected.
+have [|S /cards2P [z[w [zDw ->] [sep_zw small_zw]]]] := 
+  kconnected_bounds _ conn2Gxy nconn3Gxy; first by rewrite -ltnS card_smerge2.
+have xDy : x != y by rewrite sg_edgeNeq.
+pose x' : smerge2 G x y := Sub x xDy.
+have x_in : x' \in [set z; w]. 
+{ apply: contraPT conn3G => Hx [_ min3].
+  have /min3 := separator_from_smerge2 sep_zw Hx.
+  by rewrite card_imset // cards2; case: (_ == _). }
+wlog have: z w zDw sep_zw {x_in small_zw} / w = x' => [W|]; last subst w.
+{ case/set2P : x_in => /esym; last exact: W sep_zw.
+  rewrite eq_sym setUC in sep_zw zDw. exact: W sep_zw. }
+exists (val z); apply/vseparatorP. 
+have := smerge2_separator sep_zw.
+by rewrite imsetU !imset_set1 /= [[set _;x]]setUC setUA [[set _;x]]setUC.
+Qed.
+
+
+(* This could be an alterative to the direct argument in
+[contract_three_connected] 
+Lemma component_two_connected (G : sgraph) (x y a : G) (A : {set G}) (S := [set x; y]) : 
+  2.-connected G -> vseparator S -> 
+  a \in A -> [disjoint A & S] -> connected A -> {in A & ~: A, forall x y, x--y -> y \in S} ->
+  forall w, connected ((S :|: A) :\ w). *)
+
+
+(** The following proposition drives the inductive proof of Wagner's
+Theorem, as it allows maintainig 3-connectedness thoughout the
+induction. *)
+Proposition contract_three_connected (G : sgraph) :
+  5 <= #|G| ->
+  3.-connected G -> exists x y, x -- y /\ 3.-connected (smerge2 G x y).
+Proof.
+move=> le5G connG. 
+suff : ~ forall x y, x -- y -> ~ 3.-connected (smerge2 G x y).
+{ move => A. (* TODO: simplify? *)
+  setoid_rewrite (rwP (kconnectedP _ _)). 
+  setoid_rewrite (rwP andP).
+  do 2 setoid_rewrite (rwP existsP).
+  apply: contra_notT A => C x y xy. 
+  apply: contraNnot C => H. apply/existsP;exists x; apply/exists_inP;exists y => //.
+  exact/kconnectedP. }
+move => not3xy. 
+pose cmp3 (x y z : G) F := 
+  [/\ x -- y, vseparator [set x;y;z], connected F & [disjoint F & [set x;y;z]]].
+have [x [y [z [F [[xy sepF connF disjF] max_xyF]]]]] : exists (x y z : G) (F : {set G}), 
+    cmp3 x y z F /\ forall x' y' z' F', cmp3 x' y' z' F' -> #|F'| <= #|F|.
+{ pose p := [pred xyz : G * G * G | let: ((x,y),z) := xyz in 
+            x -- y && vseparatorb [set x;y;z]].
+  have [xyz0 p_xyz0] : exists xyz , p xyz. 
+  { have [x[y xy]] := kconnected_edge connG.
+    have [z Hz] := edge_separator le5G connG xy (not3xy _ _ xy).
+    by exists ((x,y),z); rewrite /= xy /= Hz. }
+  pose p' (xyz : G * G * G) := 
+    [pred A | let: ((x,y),z) := xyz in connectedb A && [disjoint A & [set x;y; z]]].
+  pose mcmp (xyz : G * G * G) : nat := \max_(A | p' xyz A) #|A|.
+  pose xyz := arg_max xyz0 p mcmp.
+  have inh_p' (xyz' : G * G * G) : p' xyz' set0. 
+  { case: xyz' => -[x y] z /=; rewrite disjoints0 ?andbT.
+    exact/connectedP/connected0. }
+  pose F : {set G} := arg_max set0 (p' xyz) (fun x => #|x|).
+  pose x := xyz.1.1; pose y := xyz.1.2; pose z := xyz.2.
+  exists x, y,z, F. revert xyz F x y z. 
+  case: arg_maxnP => // -[[x y] z] /= /andP [P1 P2] max_xyz. 
+  case: arg_maxnP => // F /= /andP [/connectedP connF disF] maxF.
+  split; first by split => //; exact/vseparatorP.
+  move => x' y' z' F' [F1 /vseparatorP F2 /connectedP F3 F4]. 
+  have:= max_xyz (x',y',z'); rewrite F1 F2 => /(_ isT) le_mcp.
+  apply: (@leq_trans (mcmp (x,y,z))). 
+  - apply: leq_trans le_mcp. by apply: leq_bigmax_cond => /=; rewrite F3.
+  - by apply/bigmax_leqP => A; apply: maxF. }
+have [_ min3sep] := connG.
+pose H := [set x; y] :|: F.
+have min_xyz : smallest vseparator [set x;y;z].
+{ split => // V /min3sep. apply: leq_trans. exact: cards3. }
+move defXYZ : [set x;y;z] => XYZ.
+have /set0Pn[f f_F] : F != set0.
+{ apply: contraTneq le5G => eqF0; rewrite -leqNgt.
+  suff /subset_leq_card S : G \subset [set x;y;z]. 
+    by apply: leq_trans S _; rewrite leqW // cards3.
+  apply: wlog_neg => /subsetPn [u _ Hu].
+  have:= max_xyF x y z [set u]; rewrite cards1 eqF0 cards0 ltnn.
+  case/(_ _)/Wrap => //; split; rewrite ?disjoints1 //. exact: connected1. }
+have compF : {in F & ~: F, forall u v, u -- v -> v \in XYZ}.
+{ move=> u v u_F; rewrite !inE -defXYZ => vNF uv. apply/negPn/negP => vXYZ.
+  suff/max_xyF : cmp3 x y z (v |: F). 
+    by rewrite leqNgt cardsU1 vNF add1n leqnn.
+  split => //; last by rewrite disjointsU // disjoints1.
+  rewrite setUC; apply: connectedU_edge uv _ _  => //; last exact: connected1.
+  by rewrite !inE eqxx. }
+have psepH : proper_separation (F :|: XYZ) (~: F :|: XYZ).
+{ rewrite defXYZ in min_xyz disjF.
+  exact: component_separation min_xyz f_F disjF connF compF. }
+have [u zu uNH] : exists2 u, z -- u & u \notin H.
+{ rewrite defXYZ in min_xyz.
+  have := @svseparator_neighbours _ _ _ z psepH. 
+  rewrite setUUC -{2}defXYZ !inE eqxx; case => // u [v] [_ Hz _ zv].
+  exists v => //. apply: contraNN Hz => {zv}. apply/subsetP : v. 
+  by rewrite /H setUC setUS // -defXYZ subsetUl. }
+have/andP [xDz yDz] : (x != z) && (y != z).
+{ move/min3sep : sepF. rewrite -setUA !cardsU1 cards1 !inE (sg_edgeNeq xy) /=.
+  by do 2 case: (_ == _). }
+have zNF : z \in F = false by rewrite (disjointFl disjF) // !inE eqxx.
+have zNH : z \notin H by rewrite !inE ![z == _]eq_sym !negb_or xDz yDz zNF.
+have x_H : x \in H by rewrite !inE eqxx.
+suff connH w : connected (H :\ w).
+{ (* extending the [z--u] to a separator contradicts the maximality of F *)
+  have [v /vseparatorP V2] := edge_separator le5G connG zu (not3xy _ _ zu).
+  pose F' := H :\ v.
+  have cmp3_F : cmp3 z u v F'. 
+  { split => //; first exact: connH; rewrite disjoint_sym disjoint_subset. 
+    apply/subsetP => i; rewrite !inE -orbA => /or3P[] /eqP->.
+    - by rewrite ![z == _]eq_sym (negbTE xDz) (negbTE yDz) zNF.
+    - by move: uNH; rewrite !inE => /negbTE ->.
+    - by rewrite eqxx. }
+  have:= max_xyF z u v F' cmp3_F. 
+  rewrite /F'/H -setUA => X; have {X} := leq_trans (leq_cardsD1 _ _) X.
+  rewrite !cardsU1 !inE sg_edgeNeq //= !(disjointFl disjF) ?add1n ?ltnn //.
+  all: by rewrite !inE eqxx. }
+case: (boolP (w \in [set x; y])) => [w_xy|].
+{ (* [x] and [y] cannot disconnect [H] *)
+  case/set2P : w_xy => ->. 
+  - have -> : H :\ x = F :|: [set y].
+      apply/setP => i; rewrite setUC !inE. case: (eqVneq i x) => // ->. 
+      by rewrite (sg_edgeNeq xy) /= (disjointFl disjF) // !inE eqxx.
+    have [v vy v_F] : exists2 v, v -- y & v \in F.
+    { rewrite defXYZ in min_xyz. 
+      have := @svseparator_neighbours _ _ _ y psepH. 
+      rewrite setUUC -{2}defXYZ !inE eqxx; case => // v [?] [Hv _ vy _].
+      exists v; rewrite 1?sgP //. by move: Hv; rewrite !inE negb_or negbK => /andP[]//. }
+    apply: connectedU_edge vy _ _ => //. by rewrite inE eqxx. exact: connected1.
+  - (* same as above - TODO: symmetry reasoning *)
+    have -> : H :\ y = F :|: [set x].
+      apply/setP => i; rewrite setUC !inE. case: (eqVneq i y) => // ->. 
+      by rewrite [y==x]eq_sym (sg_edgeNeq xy) /= (disjointFl disjF) // !inE eqxx.
+    have [v vx v_F] : exists2 v, v -- x & v \in F.
+    { rewrite defXYZ in min_xyz. 
+      have := @svseparator_neighbours _ _ _ x psepH. 
+      rewrite setUUC -{2}defXYZ !inE eqxx; case => // v [?] [Hv _ vx _].
+      exists v; rewrite 1?sgP //. by move: Hv; rewrite !inE negb_or negbK => /andP[]//. }
+    apply: connectedU_edge vx _ _ => //. by rewrite inE eqxx. exact: connected1. }
+rewrite !inE negb_or => /andP [wDx wDy].
+pose Cx := [set v | connect (restrict (H :\ w) sedge) x v ].
+wlog [s /setD1P [sNw s_H] sNCx] : / exists2 s, s \in H:\ w & s \notin Cx.
+{ have [/exists_inP ?|] := boolP [exists s in H :\ w, s \notin Cx]; first by apply.
+  move/exists_inPnn => C _. 
+  apply: (@connected_center _ x); last by rewrite !inE eqxx eq_sym wDx.
+  by move=> v /C; rewrite !inE. }
+suff : separates x s [set w;z]. 
+{ by move/separates_vseparator/min3sep; rewrite cards2; case (_ == _). }
+have sDx : s != x by apply: contraNneq sNCx => ->; rewrite inE connect0.
+have sDy : s != y. 
+{ apply: contraNneq sNCx => ->; rewrite inE connect1 //= xy andbT. 
+  by rewrite !inE !eqxx ![_ == w]eq_sym wDx wDy. }
+have s_F : s \in F by move: s_H; rewrite !inE (negbTE sDx) (negbTE sDy).
+have sDz : s != z by apply: contraTneq s_F => ->; rewrite zNF.
+apply: separatesI; split.
+- by rewrite !inE negb_or xDz eq_sym wDx.
+- rewrite !inE negb_or sNw /=. by apply: contraNneq zNH => <-.
+- elim/card_ind => p IHp Ip. 
+  have [z_p|zNp] := boolP (z \in p); first by exists z => //; rewrite !inE eqxx.
+  have W_xs (q : Path x s) : q \subset H -> w \in q.
+  { move/subsetP => qH; apply: contraNT sNCx => wNq; rewrite inE. 
+    apply: (connectRI q) => i i_q. rewrite inE qH // andbT inE. 
+    by apply: contraNneq wNq => <-. }
+  have [/W_xs|/subsetPn [i i_p iNH]] := boolP (p \subset H).
+  { by exists w => //; rewrite !inE eqxx. }
+  case def_p : _ / (isplitP Ip i_p) => [p1 p2 Ip1 Ip2 E1].
+  have y_p2 : y \in p2. 
+  { case: psepH => sepH _. 
+    have [] := @separation_separates _ s i _ _ sepH. 
+    - by rewrite !inE negb_or negbK s_F -defXYZ !inE (negbTE sDx) (negbTE sDy) sDz.
+    - rewrite -defXYZ setUA [F :|: _]setUC -/H inE negb_or iNH inE.
+      by apply: contraTneq i_p => ->.
+    - move => _ _ /(_ (prev p2)) [y']; rewrite setUUC mem_prev -defXYZ => y'_p2.
+      rewrite !inE -orbA => /or3P[] /eqP ?; subst y' => //. 
+      + by apply: contraNT iNH => _; rewrite -(E1 x).
+      + by rewrite def_p !inE y'_p2 orbT in zNp. }
+  case def_p2 : _ / (isplitP Ip2 y_p2) => [p21 p22 Ip21 Ip22 E2].
+  pose q := pcat (edgep xy) p22. 
+  have q_sub_p : {subset q <= p}.
+  { by move=>j; case/edgeLP => [->|]; rewrite ?def_p ?def_p2 ?inE // => ->. }
+  have [||j J1 J2] := IHp q. 
+  + apply/proper_card/properP; split; first exact/subsetP.
+    exists i => //. apply: contraNN iNH => /edgeLP [->//|i_p22]. 
+    by rewrite [i]E2 ?inE // eqxx.
+  + rewrite irred_edgeL Ip22 andbT. apply: contraTN iNH => x_p22.
+    by rewrite -(E1 x) ?negbK // def_p2 inE x_p22.
+  + exists j => //. rewrite -def_p2 -def_p. exact: q_sub_p. 
+Qed.
+
+
+(** ** Isomorphims for vertex merging *)
+
+Arguments inl_inj {A B}.
+Arguments inr_inj {A B}.
+
+(** The case for overlap 1 - one [smerge2] operation *)
+
+Lemma diso_separation1 (G : sgraph) (V1 V2 : {set G}) (x : G) (xV1 : x \in V1) (xV2 : x \in V2) : 
+  separation V1 V2 -> V1 :&: V2 = [set x] -> 
+  let G' := (induced V1 ∔ induced V2)%sg in
+  diso (smerge2 G' (inl (Sub x xV1)) (inr (Sub x xV2))) G.
+Proof.
+move=> sepV capV G'.
+have sepV' u v : u \in V1 -> v \in V2 -> u != x -> v != x -> u -- v = false.
+{ move=> uV1 vV2 uDx vDx. apply: sepV.2. 
+  - apply: contraNN uDx => uV2. by rewrite -in_set1 -capV !inE uV1.
+  - apply: contraNN vDx => vV1. by rewrite -in_set1 -capV !inE vV2. }
+set x1 : G' := inl (Sub x xV1); set x2 : G' := inr (Sub x xV2).
+set H := smerge2 _ _ _.
+have h_dec (u : G) :    ({ uV1 : u \in V1 | inl (Sub u uV1) != x2 }) 
+                      + ({ uV2 : u \in V2 | inr (Sub u uV2) != x2 }). 
+{ case: {-}_ /(boolP (u \in V1)) => [p|uNV1]; first by left; exists p.
+  have uV2 : u \in V2 by apply: sep_inR sepV _.
+  right; exists uV2; rewrite (inj_eq inr_inj) -val_eqE /=.
+  by rewrite -in_set1 -capV inE negb_and uNV1. }
+pose h (u : G) : H := 
+  match h_dec u with 
+    inl (exist uV1 uDx2) => Sub (inl (Sub u uV1)) uDx2
+  | inr (exist uV2 uDx2) => Sub (inr (Sub u uV2)) uDx2
+  end.
+pose g (x : H) : G := match val x with inl z => val z | inr z => val z end.
+have can_g : cancel g h.
+{ move => [[u uDx2|u uDx2]]; rewrite /g/h/=; apply: val_inj => /=. 
+  - case: (h_dec _) => -[uV uDx2']; first by rewrite valK'. 
+    case: notF ; rewrite (inj_eq inr_inj) -val_eqE /= in uDx2'.
+    by rewrite -in_set1 -capV inE (valP u) uV in uDx2'.
+  - case: (h_dec _) => -[uV uDx2']; last by rewrite /= valK'.
+    case: notF ; rewrite (inj_eq inr_inj) -val_eqE /= in uDx2.
+      by rewrite -in_set1 -capV inE (valP u) uV in uDx2. }
+have can_h : cancel h g.
+{ by move => u; rewrite /h/g; case: (h_dec u) => -[uV uDx2]. }
+have hom_g : is_dhom g.
+{ move => u v. 
+ rewrite {1}/edge_rel/= /g. 
+ rewrite -[sval u]/(val u) -[sval v]/(val v).
+ case: (eqVneq (val u) x1) => [->|_]; case: (eqVneq (val v) x1) => [->|_] /=.
+ - by rewrite sgP.
+ - by case: (sval v) => -[z Hz] /=; rewrite {1 2}/edge_rel/= ?orbF 1?sg_sym.
+ - by case: (sval u) => -[z Hz]; rewrite {1 2}/edge_rel/= ?orbF.
+ - by case: (sval u) => -[z Hz]; case: (sval v) => -[z' Hz']. }
+have hom_h : is_dhom h.
+{ move => u v uv; rewrite /h. 
+  case: (h_dec u) => -[uV uDx2]; case: (h_dec v) => -[vV vDx2] => //.
+  - by apply: smerge2_edge.
+  - rewrite /edge_rel/= !(inj_eq inl_inj) -!val_eqE /=.
+    rewrite (inj_eq inr_inj) -val_eqE /= in vDx2.
+    case: (eqVneq u x) => [?|vDx] /=; first by subst u; rewrite sgP. 
+    by rewrite sepV' in uv. (* violates separation property *)
+  - have uDx : u != x by rewrite (inj_eq inr_inj) -val_eqE /= in uDx2.
+    rewrite /edge_rel/= !(inj_eq inl_inj) -!val_eqE /=.
+    case: (eqVneq v x) => [?|vDx] /=; first by subst v.
+    by rewrite sgP sepV' in uv. (* violates separation property *) }
+exact: Diso'' can_g can_h _ _.
+Qed.
+
+(** The case for overlap 2 - two [smerge2] operations *)
+
+(** In the case of a proper separtion [(V1,V2)] that overlaps in a set
+[[set x;y]] with [x -- y], we need two [smerge2] operations to
+collapse [induced V1] and [induced V2]. Given the complex definition
+of the edge relation for [smerge2], this leads to a rather messy
+construction. To alleviate this somewhat, we introduce an intermediate
+construction [glue2] that merges two vertices from different graphs in
+one go. *)
+
+Section Glue2.
+Variables (G : sgraph) (x y : G) (H : sgraph) (x' y' : H).
+
+Definition glue2_vertex : Type := G + { z | z \notin [set x';y'] }.
+
+Definition glue2_rel (u v : glue2_vertex) :=
+  match u,v with
+  | inl u, inl v => u -- v
+  | inr u, inr v => val u -- val v
+  | inl u, inr v => (u == x) && x' -- val v || (u == y) && y' -- val v
+  | inr v, inl u => (u == x) && x' -- val v || (u == y) && y' -- val v
+  end.
+
+Lemma glue2_sym : symmetric glue2_rel.
+Proof. move => [u|u] [v|v] //=; by rewrite sgP. Qed.
+
+Lemma glue2_irrefl : irreflexive glue2_rel.
+Proof. by move => [u|u] /=; rewrite sgP. Qed.
+
+Definition glue2 := SGraph glue2_sym glue2_irrefl.
+
+(** injection for elements of H *)
+Definition glue2_r (z : H) : glue2.
+refine (
+  if @boolP (z == x') isn't AltFalse b1 then inl x else
+    if @boolP (z == y') isn't AltFalse b2 then inl y else
+      inr (Sub z _)  
+); abstract (by rewrite !inE negb_or b1 b2).
+Defined.
+
+End Glue2.
+Arguments glue2 : clear implicits.
+Arguments glue2_r [G x y H x' y'] _.
+
+Open Scope implicit_scope.
+
+Lemma smerge2_glue2 (G H : sgraph) (x1 y1 : G) (x2 y2 : H) (p1 : inl y1 != inr x2) (p2 : inr y2 != inr x2) :
+  x1 != y1 -> x1 -- y1 ->
+  diso (smerge2 (smerge2 (G ∔ H)%sg (inl x1) (inr x2)) (Sub (inl y1) p1) (Sub (inr y2) p2))
+       (glue2 G x1 y1 H x2 y2).
+Proof.
+move=> x1Dy1 x1y1.
+set U' := smerge2 (G ∔ H)%sg (inl x1) (inr x2).
+set U := smerge2 _ _ _.
+(* neither smerge2 operation contracts an edge *)
+have x1Nx2 : ~~ inl x1 -- inr x2 :> (G ∔ H)%sg by [].
+have y1Ny2 p q : ~~ (Sub (inl y1) p) -- (Sub (inr y2) q) :> U'.
+{ by rewrite /edge_rel/= eq_sym (inj_eq inl_inj) (negbTE x1Dy1). }
+set V := glue2 _ _ _ _ _ _.
+pose f (u : U) : V :=
+  match val (val u) with
+  | inl z => inl z 
+  | inr z => glue2_r z
+  end.
+pose y1' : U := (Sub (Sub (inl y1) isT) isT).
+pose x1' : U' := (Sub (inl x1) isT).
+pose g (v : V) : U := 
+  match v with
+  | inl z => Sub (Sub (inl z) isT) isT
+  | inr z => insubd y1' (insubd x1' (inr (val z)))
+  end.
+have gP1 z : z \notin [set x2; y2] -> val (insubd x1' (inr z)) = inr z.
+{ move=> ?; rewrite insubdK // -topredE/= (inj_eq inr_inj); set_tac. }
+have gP2 z : z \notin [set x2; y2] -> val (val (insubd y1' (insubd x1' (inr z)))) = inr z.
+{ move=> ?. rewrite val_insubd -val_eqE gP1 //= ifT ?gP1 // (inj_eq inr_inj). by set_tac. }
+have can_f : cancel f g.
+{ rewrite /f/g. move => [[[u|u] U2] U1] => /=; do 2 apply: val_inj => //=.
+  rewrite /glue2_r altF altF. rewrite !insubdK //=.
+  rewrite -val_eqE /= in U1. by rewrite -topredE/= -val_eqE insubdK. }
+have can_g : cancel g f.
+{ rewrite /f/g. move => [v|[v Hv]] //=. 
+  move : {-}(Hv); rewrite !(inE,negb_or) => /andP[vDx2 vDy2]. 
+  rewrite insubdK; last by rewrite -topredE/= -val_eqE /= val_insubd vDx2.
+  rewrite insubdK // /glue2_r !altF; congr (inr _). exact: val_inj. }
+have hom_g : is_dhom g.
+{ move => [u|[u Hu]] [v|[v Hv]]; rewrite /g/=.
+  - move => ?. by do 2 apply: smerge2_edge. 
+  - rewrite {1}/edge_rel/=. case/orP => -/andP[/eqP-> ev].
+    + apply: smerge2_edge. apply: smerge2edgeL => //; by rewrite gP2 // sgP.
+    + apply: smerge2edgeL => //; first by rewrite -val_eqE.
+      by apply: smerge2_edge; rewrite gP2 //= sgP.
+  - rewrite {1}/edge_rel/=. case/orP => -/andP[/eqP-> ev].
+    + rewrite sgP. apply: smerge2_edge. apply: smerge2edgeL => //. 
+      by rewrite gP2 // sgP.
+    + rewrite sgP. apply: smerge2edgeL => //; first by rewrite -val_eqE.
+      by apply: smerge2_edge; rewrite gP2 //= sgP.
+  - rewrite {1}/edge_rel/= => uv. do 2 apply: smerge2_edge. by rewrite !gP2. }
+have hom_f : is_dhom f.
+{ rewrite /is_dhom. apply: smerge2Ecase => //; first by move=> ? ?; rewrite sgP.
+  - (* edge of inner smerge operation (megring x1 and x2 *)
+    move => [u Hu] [v Hv] /= uv. move: Hu Hv. pattern u,v. 
+    apply: smerge2Ecase => //= {u v uv}.
+    + move=> u v; split => A Hu Hv; rewrite sgP; apply: A. 
+    + (* original edge *)
+      move => [[u|u] Hu] [[v|v] Hv] //; rewrite /f/=. 
+      rewrite -?val_eqE /= !(inj_eq inr_inj) => uv uDy2 vDy2. 
+      by rewrite /glue2_r !altF /edge_rel/=.
+    + (* edge modified by inner smerge2 operation *)
+      move => [[u|u] Hu] // [[v|v] Hv] //=; first by rewrite andbF.
+      case/andP=> [eq_u vx2]; rewrite /f/= -val_eqE /= (inj_eq inr_inj) => _ vDy2.
+      rewrite /glue2_r 2!altF /edge_rel/=; apply/orP;left; apply/andP; split => //.
+      by rewrite sgP.       
+  - (* edge modified by outer smerge2 operation *)
+    move => [u Hu] [v Hv] /= => /andP[/eqP ?]; subst u; rewrite /f/=.
+    rewrite smerge2edgeD // => /or3P [].
+    + case: v Hv => -[v|v] Hv' Hv //= vy2. rewrite -val_eqE /= in Hv.
+      rewrite /glue2_r 2!altF. rewrite /edge_rel/= eqxx [y2 -- _]sgP.
+      by apply/orP; right.
+    + case/andP => [def_v E]. rewrite (eqP def_v).
+      by rewrite /edge_rel/= sgP.
+    + done. }
+exact: Diso'' can_f can_g hom_f hom_g.
+Qed.
+
+Lemma separation_capN (G : sgraph) (V1 V2 : {set G}) u v :
+  separation V1 V2 -> u \in V1 -> v \in V2 -> u -- v -> (u \in V1 :&: V2) || (v \in V1 :&: V2).
+Proof.
+move => sepV uV1 vV2 uv; rewrite !inE uV1 vV2 andbT /=. 
+by apply: contraTT uv; rewrite negb_or => /andP[uNV2 vNV1]; rewrite sepV.
+Qed.
+
+Lemma diso_separation2_glue (G : sgraph) (V1 V2 : {set G}) (x y : G) 
+  (xV1 : x \in V1) (xV2 : x \in V2) (yV1 : y \in V1) (yV2 : y \in V2) : 
+  separation V1 V2 -> V1 :&: V2 = [set x;y] -> 
+  diso (glue2 (induced V1) (Sub x xV1) (Sub y yV1) (induced V2) (Sub x xV2) (Sub y yV2)) G.
+Proof.
+set x' := Sub x xV2; set y' := Sub y yV2.
+move => sepV capV; set H := glue2 _ _ _ _ _ _.
+pose g (u : H) : G := 
+  match u with inl u => val u | inr u => val (val u) end.
+have h_dec (u : G) : (u \in V1) + ({ uV2 : u \in V2 | Sub u uV2 \notin [set x';y'] }). 
+{ case: (boolP (u \in V1)) => [|uV1]; [by left|right].
+  by exists (sep_inR sepV uV1); rewrite in_set2 -!val_eqE /= -in_set2 -capV inE (negbTE uV1). }
+have h_dec_l u (uV1 : u \in V1) : h_dec u = inl uV1.
+{ case: (h_dec u) => [uV1'|[uV2 p]]; first by congr(inl _); exact: bool_irrelevance.
+  case: notF. by rewrite in_set2 -!val_eqE /= -in_set2 -capV !inE uV1 uV2 in p. }
+have h_dec_r u (uV2 : u \in V2) (p : Sub u uV2 \notin [set x';y']) : h_dec u = inr (Sub uV2 p).
+{ case: (h_dec u) => [uV1|[uV2' p']]; last by congr (inr _); apply: val_inj; apply: bool_irrelevance.
+  case: notF. by rewrite in_set2 -!val_eqE /= -in_set2 -capV !inE uV1 uV2 in p. }
+pose h (u : G) : H := 
+  match h_dec u with 
+  | inl uV1 => inl (Sub u uV1) 
+  | inr (exist uV2 p) => inr (Sub (Sub u uV2) p)
+  end.
+have can_g : cancel g h.
+{ move => [[u uV1]|[[u uV2] p]]; rewrite /h/g/=. 
+  + by rewrite h_dec_l.
+  + by rewrite h_dec_r. }
+have can_h : cancel h g.
+{ by move => u; rewrite /h; case: (h_dec _) => [uV1|[uV1 p]]. }
+have hom_g : is_dhom g.
+{ move=> u v. rewrite [u -- v]/edge_rel/=.
+  move: u v => [u|u] [v|v] //=. by case/orP => [/andP[/eqP->]|/andP[/eqP->]].
+  case/orP => [/andP[/eqP->]|/andP[/eqP->]] //; by rewrite sgP. }
+have hom_h : is_dhom h.
+{ move => u v uv. rewrite /h/edge_rel/=. 
+  case: (h_dec u) => [uV1|[uV2 p]]; case: (h_dec v) => [vV1|[vV2 q]] /=.
+  1,4 : by rewrite -induced_val_edge.
+  - rewrite !inE -!val_eqE /= -in_set2 in q.
+    rewrite -!val_eqE -!induced_val_edge /=. 
+    have := separation_capN sepV uV1 vV2 uv; rewrite capV (negbTE q) orbF.
+    by case/set2P => ?; subst u; rewrite eqxx uv.
+  - rewrite !inE -!val_eqE /= -in_set2  in p.
+    rewrite -!val_eqE -!induced_val_edge /=; rewrite sgP in uv.
+    have := separation_capN sepV vV1 uV2 uv; rewrite capV (negbTE p) orbF.
+    by case/set2P => ?; subst v; rewrite eqxx uv. }
+exact: Diso'' hom_g hom_h.
+Qed.
+
+Lemma diso_separation2 (G : sgraph) (V1 V2 : {set G}) (x y : G) 
+   (xV1 : x \in V1) (xV2 : x \in V2) (yV1 : y \in V1) (yV2 : y \in V2)
+   (G1 := induced V1) (G2 := induced V2) (G12 := (G1 ∔ G2)%sg)
+   (x1 : G12 := inl (Sub x xV1)) (x2 : G12 := inr (Sub x xV2))
+   (y1 : G12 := inl (Sub y yV1)) (y2 : G12 := inr (Sub y yV2))
+   (y1Gm : y1 != x2) (y2Gm : y2 != x2) :
+  separation V1 V2 -> V1 :&: V2 = [set x; y] -> x -- y ->
+  diso (smerge2 (smerge2 (G1 ∔ G2) x1 x2) (Sub y1 y1Gm) (Sub y2 y2Gm)) G.
+Proof.
+move=> sepV capV xy.
+have := diso_separation2_glue xV1 xV2 yV1 yV2 sepV capV.
+apply: diso_comp. apply: smerge2_glue2 => //.
+by rewrite -val_eqE /= sg_edgeNeq.
+Qed.

--- a/theories/transfer.v
+++ b/theories/transfer.v
@@ -1051,7 +1051,10 @@ Qed.
 (** We need one expansion lemma for every rule *)
 
 (* TODO: why is [simple apply] unable to use the non-instantiated lemmas? *)
-Hint Resolve (@in_vsetDV tm) (@in_vsetDE tm) (@in_vsetAE tm) (@in_vsetAV tm) (@in_vsetAV' tm) : vset.
+(* Hint Resolve in_vsetDV in_vsetDE in_vsetAE in_vsetAV in_vsetAV' : vset. *)
+Set Warnings "-fragile-hint-constr".
+Local Hint Resolve (@in_vsetDV tm) (@in_vsetDE tm) (@in_vsetAE tm) (@in_vsetAV tm) (@in_vsetAV' tm) : vset.
+Set Warnings "+fragile-hint-constr".
 
 Lemma expand_isolated (G : pre_graph) (z : VT) (isG : is_graph G) (isH : is_graph (G \ z)) :
     z \in vset G -> edges_at G z = fset0 -> pack G ≃2 pack (G \ z) ∔ lv G z.


### PR DESCRIPTION
This PR combines the "cominatorial" (in the sense of not depending on plane embeddings) part of Wagner's theorem. This mainly involves 
- a substantial collection of lemmas on the `arc` predicate, used for splitting a cycle into an arbitrary number of segments along a sub-cycle (`arc.v`). 
- the concept of k-connectivity and associated lemmas.
- lemmas about the operation of merging two vertices (`smerge.v`)

The most interesting result in this part is that 3-connected graphs of size at least 5 have an edge that can be contracted while preserving 3-connectedness (`contract_three_connected` in `smerge.v`). 

