### PR TITLE
update for mathcomp-1.13 and mathcomp-1.14

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'mathcomp/mathcomp-dev:coq-dev'
+          - 'coqorg/coq:dev-ocaml-4.13-flambda'
           - 'mathcomp/mathcomp:1.14.0-coq-8.15'
           - 'mathcomp/mathcomp:1.13.0-coq-8.14'
       fail-fast: false

--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         image:
           - 'mathcomp/mathcomp-dev:coq-dev'
-          - 'mathcomp/mathcomp:1.12.0-coq-8.13'
-          - 'mathcomp/mathcomp:1.12.0-coq-8.12'
+          - 'mathcomp/mathcomp:1.14.0-coq-8.15'
+          - 'mathcomp/mathcomp:1.13.0-coq-8.14'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ Follow the instructions on https://github.com/coq-community/templates to regener
 [![Chat][chat-shield]][chat-link]
 [![Contributing][contributing-shield]][contributing-link]
 [![Code of Conduct][conduct-shield]][conduct-link]
+[![Zulip][zulip-shield]][zulip-link]
 [![DOI][doi-shield]][doi-link]
 
 [docker-action-shield]: https://github.com/coq-community/graph-theory/workflows/Docker%20CI/badge.svg?branch=master
 [docker-action-link]: https://github.com/coq-community/graph-theory/actions?query=workflow:"Docker%20CI"
-[chat-shield]: https://img.shields.io/badge/zulip-join_chat-brightgreen.svg
+[chat-shield]: https://img.shields.io/badge/Zulip-join_chat-brightgreen.svg
 [chat-link]: https://coq.zulipchat.com/#narrow/stream/284683-GraphTheory
 
 [contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg

--- a/coq-graph-theory.opam
+++ b/coq-graph-theory.opam
@@ -26,8 +26,8 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.12" & < "8.14~") | (= "dev")}
-  "coq-mathcomp-algebra" {(>= "1.12" & < "1.13~") | (= "dev")}
+  "coq" {(>= "8.12" & < "8.16~") | (= "dev")}
+  "coq-mathcomp-algebra" {(>= "1.12" & < "1.15~") | (= "dev")}
   "coq-mathcomp-finmap" 
   "coq-hierarchy-builder" { (>= "1.1.0") }
 ]

--- a/meta.yml
+++ b/meta.yml
@@ -62,14 +62,14 @@ license:
 
 supported_coq_versions:
   text: 8.12 or later
-  opam: '{(>= "8.12" & < "8.14~") | (= "dev")}'
+  opam: '{(>= "8.12" & < "8.16~") | (= "dev")}'
 
 tested_coq_opam_versions:
 - version: 'coq-dev'
   repo: 'mathcomp/mathcomp-dev'
-- version: '1.12.0-coq-8.13'
+- version: '1.14.0-coq-8.15'
   repo: 'mathcomp/mathcomp'
-- version: '1.12.0-coq-8.12'
+- version: '1.13.0-coq-8.14'
   repo: 'mathcomp/mathcomp'
 
 ci_cron_schedule: '25 5 * * *'
@@ -77,7 +77,7 @@ ci_cron_schedule: '25 5 * * *'
 dependencies:
 - opam:
     name: coq-mathcomp-algebra
-    version: '{(>= "1.12" & < "1.13~") | (= "dev")}'
+    version: '{(>= "1.12" & < "1.15~") | (= "dev")}'
   description: MathComp's Algebra library, version 1.12 or later
 - opam:
     name: coq-mathcomp-finmap

--- a/theories/bij.v
+++ b/theories/bij.v
@@ -74,6 +74,7 @@ Proof.
   econstructor; apply can_comp. apply g. apply f. apply f. apply g. 
 Defined.
 
+#[export]
 Instance bij_Equivalence: Equivalence bij.
 Proof. constructor. exact @bij_id. exact @bij_sym. exact @bij_comp. Defined.
 
@@ -82,6 +83,7 @@ Proof. constructor. exact @bij_id. exact @bij_sym. exact @bij_comp. Defined.
 Definition sumf {A B C D} (f: A -> B) (g: C -> D) (x: A+C): B+D :=
   match x with inl a => inl (f a) | inr c => inr (g c) end. 
 
+#[export]
 Instance sum_bij: Proper (bij ==> bij ==> bij) sum.
 Proof.
   intros A A' f B B' g.

--- a/theories/coloring.v
+++ b/theories/coloring.v
@@ -449,7 +449,7 @@ by apply: sub_clique clK; rewrite sub_imset_pre preimsetS.
 Qed.
 
 Lemma can_inj_imset (A : {set F}) : i @^-1: (i @: A) = A.
-Proof. by apply/setP => x; rewrite !inE (mem_imset_eq). Qed.
+Proof. by apply/setP => x; rewrite !inE (mem_imset). Qed.
 
 Lemma omega_isubgraph (B : {set F}) : ω(B) = ω(i @: B).
 Proof.

--- a/theories/connectivity.v
+++ b/theories/connectivity.v
@@ -408,12 +408,12 @@ Lemma induced_separates (V : {set G}) (S : {set induced V}) (x y : induced V) :
   separates x y S -> separates (val x) (val y) (val @: S :|: ~:V).
 Proof.
 case => xS yS sepS.
-split => [||p]; rewrite ?inE ?negb_or ?negbK ?mem_imset_eq ?xS ?yS ?(valP x) ?(valP y) //=. 
+split => [||p]; rewrite ?inE ?negb_or ?negbK ?mem_imset ?xS ?yS ?(valP x) ?(valP y) //=. 
 case: (boolP (p \subset V)) => [/subsetP subA|/subsetPn [z Z1 Z2]]; last first.
    by exists z; rewrite ?inE ?Z1 ?Z2.
 have [q nodes_q] := Path_to_induced subA.
 have [z Z1 Z2] := sepS q.
-exists (val z); by [rewrite mem_path -nodes_q map_f|rewrite !inE mem_imset_eq ?Z2].
+exists (val z); by [rewrite mem_path -nodes_q map_f|rewrite !inE mem_imset ?Z2].
 Qed.
 
 

--- a/theories/digraph.v
+++ b/theories/digraph.v
@@ -1030,7 +1030,7 @@ Proof.
   apply Diso with (bij_comp f g); apply dhom_comp. apply f. apply g. apply g. apply f. 
 Defined.
 
-Instance diso_Equivalence: Equivalence diso.
+#[export] Instance diso_Equivalence: Equivalence diso.
 constructor. exact @diso_id. exact @diso_sym. exact @diso_comp. Defined.
 
 Lemma edge_diso' F G (h: diso F G) x y: h^-1 x -- h^-1 y = x -- y.

--- a/theories/embedding.v
+++ b/theories/embedding.v
@@ -656,9 +656,9 @@ Lemma add_node_diso_proof (G : sgraph) (A : {set G}) (x : G) : x \in A ->
   =2 add_node_rel A.
 Proof.
 move=> x_A [u|] [v|] //=; rewrite [in LHS]/edge_rel/= ?inE //.
-- rewrite andbT andFb /= mem_imset_eq ?inE; last exact: Some_inj.
+- rewrite andbT andFb /= mem_imset ?inE; last exact: Some_inj.
   by have [->|//] := eqVneq u x; rewrite x_A.
-- rewrite andbF andTb orbF mem_imset_eq ?inE; last exact: Some_inj.
+- rewrite andbF andTb orbF mem_imset ?inE; last exact: Some_inj.
   by have [->|//] := eqVneq v x; rewrite x_A.
 Qed.
 

--- a/theories/equiv.v
+++ b/theories/equiv.v
@@ -106,6 +106,7 @@ Lemma eqv_clot_trans (T: finType) (z x y: T) (l: pairs T):
   eqv_clot l x z -> eqv_clot l z y -> eqv_clot l x y.
 Proof. exact: equiv_trans. Qed.
 
+#[export]
 Instance equiv_rel_Equivalence T (e : equiv_rel T) : Equivalence [eta e].
 Proof. split => // [x y|x y z]; by [rewrite equiv_sym | apply: equiv_trans]. Qed.
   

--- a/theories/hcycle.v
+++ b/theories/hcycle.v
@@ -308,4 +308,3 @@ apply/and3P; split.
     * by rewrite (disjointFl dis_q_f) // def_c' !(inE,mem_rcons,mem_cat) H in Z1. 
 Qed.
 
-Print Assumptions two_connected_cyle.

--- a/theories/hmap_ops.v
+++ b/theories/hmap_ops.v
@@ -1839,7 +1839,7 @@ have -> : order add_node_face IcpX = (arity x).+2.
     case: (eqVneq z IcpXe) => [->|]; first by rewrite connect1.
     have ? := @faceI h_add_node.
     case: z => [z||]//= z _ _; rewrite same_fconnect1 //= same_fconnect1 //=.
-    rewrite /IcpF mem_imset_eq // inE. exact: add_node_cfaceE. }
+    rewrite /IcpF mem_imset // inE. exact: add_node_cfaceE. }
 rewrite /=; congr [:: _ , _ & _].
 apply: (@eq_from_nth _ (Icp x)); first by rewrite size_map !size_traject.
 move => n; rewrite size_traject => lt_n_st. 

--- a/theories/partition.v
+++ b/theories/partition.v
@@ -115,15 +115,15 @@ Let fP := [set f @: (S : {set T}) | S in P].
 Lemma imset_inj : injective (fun A : {set T} => f @: A).
 Proof. 
 move => A B => /setP E; apply/setP => x. 
-by rewrite -(mem_imset_eq (mem A) x inj_f) E mem_imset_eq.
+by rewrite -(mem_imset (mem A) x inj_f) E mem_imset.
 Qed.
 
 Lemma imset_disjoint (A B : {pred T}) :
   [disjoint f @: A & f @: B] = [disjoint A & B].
 Proof.
 apply/pred0Pn/pred0Pn => /= [[? /andP[/imsetP[x xA ->]] xB]|].
-  by exists x; rewrite xA -(mem_imset_eq (mem B) x inj_f).
-by move => [x /andP[xA xB]]; exists (f x); rewrite !mem_imset_eq ?xA.
+  by exists x; rewrite xA -(mem_imset (mem B) x inj_f).
+by move => [x /andP[xA xB]]; exists (f x); rewrite !mem_imset ?xA.
 Qed.
 
 Lemma imset_trivIset : trivIset P = trivIset fP.

--- a/theories/preliminaries.v
+++ b/theories/preliminaries.v
@@ -836,7 +836,7 @@ Lemma imset_inj (aT rT : finType) (f : aT -> rT) :
   injective f -> injective (fun A : {set aT} => f @: A).
 Proof.
 move=> inj_f A B eq_AB; apply/setP => x.
-by rewrite -(mem_imset_eq _ _ inj_f) eq_AB mem_imset_eq.
+by rewrite -(mem_imset _ _ inj_f) eq_AB mem_imset.
 Qed.
 
 Lemma imset_pre_val (T : finType) (P : pred T) (s : subFinType P) (A : {set T}) :
@@ -878,8 +878,8 @@ Lemma inj_imsetS (aT rT : finType) (f : aT -> rT) (A B : {pred aT}) :
   injective f -> (f @: A \subset f @: B) = (A \subset B).
 Proof.
 move=> inj_f; apply/subsetP/subsetP => [/= subAB x xA|subAB ? /imsetP[x xA ->]]. 
-  by move: (subAB (f x)); rewrite !(mem_imset_eq _ _ inj_f); apply.
-by rewrite (mem_imset_eq _ _ inj_f); apply: subAB.
+  by move: (subAB (f x)); rewrite !(mem_imset _ _ inj_f); apply.
+by rewrite (mem_imset _ _ inj_f); apply: subAB.
 Qed.
 
 Lemma val_subset (T: finType) (H : {set T}) (A B : {set sig [eta mem H]}) :
@@ -966,6 +966,7 @@ Qed.
 
 (** Extra Morphism declatations *)
 
+#[export]
 Instance ex2_iff_morphism (A : Type) :  
   Proper (pointwise_relation A iff ==> pointwise_relation A iff ==> iff) (@ex2 A).
 Proof. by firstorder. Qed.
@@ -1075,7 +1076,7 @@ Proof. rewrite inE; exact: idP. Qed.
 
 Lemma Sub_imset (T : finType) (P : {pred T}) (s : subFinType P) {A : {set s}} (x : T) (Px : P x) :
   (Sub x Px \in A) = (x \in val @: A).
-Proof. by rewrite -[X in X \in val @: _](SubK s Px) mem_imset_eq. Qed.
+Proof. by rewrite -[X in X \in val @: _](SubK s Px) mem_imset. Qed.
 
 Lemma Sub_map (T : eqType) (P : {pred T}) (s : subType P) {A : seq s} (x : T) (Px : P x) :
   (Sub x Px \in A) = (x \in map val A).

--- a/theories/ptt.v
+++ b/theories/ptt.v
@@ -72,12 +72,15 @@ HB.builders Context A (F : Ptt_of_Ops A).
 
 HB.end.
 
+#[export]
 Instance ptt_equivalence (A : ptt) : Equivalence (@eqv [the ptt of A]).
 Proof. exact: Eqv. Qed.
 
+#[export]
 Instance ptt_par_eqv (A : ptt) : Proper (eqv ==> eqv ==> eqv) (par : A -> A -> A).
 Proof. exact: par_eqv. Qed.
 
+#[export]
 Instance ptt_dot_eqv (A : ptt) : Proper (eqv ==> eqv ==> eqv) (dot : A -> A -> A).
 Proof. exact: dot_eqv. Qed.
 

--- a/theories/pttdom.v
+++ b/theories/pttdom.v
@@ -61,7 +61,7 @@ HB.mixin Record Pttdom_of_Ops A of Ops_of_Type A & Setoid_of_Type A :=
   }.
 HB.structure Definition Pttdom := { A of Pttdom_of_Ops A & }.
 Notation pttdom := Pttdom.type.
-Existing Instances dot_eqv par_eqv cnv_eqv dom_eqv.
+#[export] Existing Instances dot_eqv par_eqv cnv_eqv dom_eqv.
 
 Class is_test (X : pttdom) (x : X) := { testE : dom x ≡ x }.
 
@@ -205,6 +205,7 @@ Section derived.
  Lemma eqv11 x y z: eqv' x y -> eqv' y z -> x ≡ z.
  Proof. move=> /= -> ->. apply cnvI. Qed.
 
+ #[export,non_forgetful_inheritance]
  HB.instance Definition pttdom_elabel := 
    Elabel_of_Setoid.Build X eqv'_sym eqv01 eqv11.
  

--- a/theories/sgraph.v
+++ b/theories/sgraph.v
@@ -1396,9 +1396,9 @@ Lemma add_node_diso_proof (G : sgraph) (A : {set G}) (x : G) : x \in A ->
   =2 add_node_rel A.
 Proof.
 move=> x_A [u|] [v|] //=; rewrite [in LHS]/edge_rel/= ?inE //.
-- rewrite andbT andFb /= mem_imset_eq ?inE; last exact: Some_inj.
+- rewrite andbT andFb /= mem_imset ?inE; last exact: Some_inj.
   by have [->|//] := eqVneq u x; rewrite x_A.
-- rewrite andbF andTb orbF mem_imset_eq ?inE; last exact: Some_inj.
+- rewrite andbF andTb orbF mem_imset ?inE; last exact: Some_inj.
   by have [->|//] := eqVneq v x; rewrite x_A.
 Qed.
 
@@ -1721,14 +1721,14 @@ Qed.
 Lemma opn_Knm_l n m (x : 'I_n) : 
   N(inl x : 'K_n,m) = [set inr y | y in [set: 'I_m]].
 Proof.
-apply/setP=> -[z|z]; rewrite ?mem_imset_eq ?inE //; last exact: inr_inj.
+apply/setP=> -[z|z]; rewrite ?mem_imset ?inE //; last exact: inr_inj.
 by symmetry; apply: contraTF isT => /imsetP [z']. 
 Qed.
 
 Lemma opn_Knm_r n m (y : 'I_m) : 
   N(inr y : 'K_n,m) = [set inl x | x in [set: 'I_n]].
 Proof.
-apply/setP=> -[z|z]; rewrite ?mem_imset_eq ?inE //; first exact: inl_inj.
+apply/setP=> -[z|z]; rewrite ?mem_imset ?inE //; first exact: inl_inj.
 by symmetry; apply: contraTF isT => /imsetP [z']. 
 Qed.
 
@@ -1767,7 +1767,7 @@ rewrite edges_add_node cardsU disjoint_setI0 ?cards0 ?subn0; first congr (_ + _)
 - apply: card_imset => x y /setP /(_ (Some y)); rewrite !inE eqxx orbT.
   by rewrite Some_eqE => /eqP ->.
 - apply: card_imset => e1 e2 eq_Some; apply/setP => x.
-  by rewrite -[LHS](mem_imset_eq _ _ Some_inj) eq_Some mem_imset_eq.
+  by rewrite -[LHS](mem_imset _ _ Some_inj) eq_Some mem_imset.
 - apply/disjointP => e E1 E2. 
   have: None \in e by case/imsetP : E1 => x _ ->; rewrite !inE eqxx.
   suff: None \notin e by move/negPf->.

--- a/theories/skeleton.v
+++ b/theories/skeleton.v
@@ -570,7 +570,7 @@ Proof.
   rewrite (lock edge_rel) /= -!andbA -lock. case/and4P=> _ a_U' xa.
   have Ha : a \in V by case/imsetP: a_U' => b _ ->; exact: valP.
   set b : subgraph_for con := Sub a Ha. rewrite -[a]/(val b) => p_path p_last.
-  have b_U : b \in U by rewrite -(mem_imset_eq _  _ val_inj).
+  have b_U : b \in U by rewrite -(mem_imset _  _ val_inj).
   apply: connect_trans (IH b b_U p_path p_last). apply: connect1 => /=.
   apply/andP; split; first by apply/andP; split. move: xa.
 

--- a/theories/smerge.v
+++ b/theories/smerge.v
@@ -180,14 +180,14 @@ Lemma smerge2_separator (G : sgraph) (x y : G) (S : {set smerge2 G x y}) :
 Proof.
 move => [u[v [uNS vNS sep_uv]]]. 
 exists (val u),(val v); split => [||p].
-- rewrite !inE (negbTE (valP u)) /= mem_imset_eq //; exact: val_inj.
-- rewrite !inE (negbTE (valP v)) /= mem_imset_eq //; exact: val_inj.
+- rewrite !inE (negbTE (valP u)) /= mem_imset //; exact: val_inj.
+- rewrite !inE (negbTE (valP v)) /= mem_imset //; exact: val_inj.
 - have [|yNp] := boolP (y \in p); first by exists y => //; rewrite !inE eqxx.
   have [|//||q eq_q _] := lift_Path (p' := p).
   + exact: smerge2_edge.
   + move => z z_p. have zDy : z != y by apply: contraTneq z_p => ->.
     by apply/mapP; exists (Sub z zDy) => //; rewrite mem_enum.
-  + have [z z_q z_S] := sep_uv q; exists (val z); last by rewrite !inE mem_imset_eq ?z_S.
+  + have [z z_q z_S] := sep_uv q; exists (val z); last by rewrite !inE mem_imset ?z_S.
     by rewrite mem_path -eq_q mem_map.
 Qed. 
 
@@ -240,7 +240,7 @@ split; first split.
   rewrite /edge_rel/=. rewrite (negbTE vDx) /= andbT.
   by case: (eqVneq u x) => [<-|//]; rewrite [v -- u]sgP uv.
 - case: psepV => _ [u [v [u_V1 v_V2]]]. 
-  exists (val u),(val v). by rewrite !(inE,mem_imset_eq) // negb_or (valP v).
+  exists (val u),(val v). by rewrite !(inE,mem_imset) // negb_or (valP v).
 Qed.
 
 Lemma edge_separator (G : sgraph) (x y : G) : 

--- a/theories/structures.v
+++ b/theories/structures.v
@@ -73,7 +73,7 @@ HB.mixin Record ComMonoid_of_Setoid A of Setoid_of_Type A :=
 HB.structure Definition ComMonoid := { A of ComMonoid_of_Setoid A & }.
 Notation comMonoid := ComMonoid.type.
 
-Existing Instance cm_laws.
+#[export] Existing Instance cm_laws.
 Arguments cm_op {_} _ _.
 Declare Scope cm_scope.
 Delimit Scope cm_scope with CM.

--- a/theories/transfer.v
+++ b/theories/transfer.v
@@ -42,9 +42,8 @@ Lemma inj_e_inj : injective inj_e.
 Proof. move => x y. by move/ord_inj/enum_rank_inj. Qed.
 
 End inject.
-#[export]
-Hint Resolve inj_v_inj inj_e_inj : core.
-Instance VT_inh_type : inh_type VT := Build_inh_type 0. 
+#[export] Hint Resolve inj_v_inj inj_e_inj : core.
+#[export] Instance VT_inh_type : inh_type VT := Build_inh_type 0. 
 Arguments inj_v {T}.
 Arguments inj_e {T}.
 
@@ -1286,4 +1285,3 @@ Qed.
 
 
 End PttdomGraphTheory.
-

--- a/theories/treewidth.v
+++ b/theories/treewidth.v
@@ -506,7 +506,7 @@ Section DecompTheory.
         exists z; exists x. rewrite sgP. split => //. apply: contraNT zNC => H.
         rewrite 2!inE /= in xC. case/andP : xC => H1 H2.
         rewrite 2!inE /= (negbTE H) /=. apply: connect_trans H2 _.
-        apply: connect1 => /=. by  rewrite 2!inE H1 2!inE xz H. }
+        apply: connect1 => /=; by rewrite !in_simpl H1 xz H. }
       (* Every path into [C] must use this edge (and [c0]) *)
       have t0P c' (p : Path t0 c') : irred p -> c' \in C -> c0 \in p.
       { move => Ip inC'.

--- a/theories/wagner.v
+++ b/theories/wagner.v
@@ -389,28 +389,28 @@ have [] := @plane_add_node' _ g2 x2 x1 s2 [set z in X] => //.
     { move => [[u|]|] [[v|]|] //=.
       - move => uv. by rewrite (@smerge2_val_edge _ x y) ?induced_edge //; exact: G2Dx.
       - by rewrite {1}/edge_rel/={1}/edge_rel/= inE mem_filter sgP => /andP[-> _].
-      - by rewrite {1}/edge_rel/= !(inE, mem_imset_eq) // orFb mem_filter sgP => /andP[-> _].
+      - by rewrite {1}/edge_rel/= !(inE, mem_imset) // orFb mem_filter sgP => /andP[-> _].
       - by rewrite {1}/edge_rel/={1}/edge_rel/= inE mem_filter => /andP[-> _].
-      - by rewrite {1}/edge_rel/= !(inE, mem_imset_eq) // orFb mem_filter => /andP[-> _].
+      - by rewrite {1}/edge_rel/= !(inE, mem_imset) // orFb mem_filter => /andP[-> _].
       - by rewrite [y -- x]sgP. }
     have inG2Y u : u != x -> u != y -> u -- y -> inG2 u \in Y.
-    { move=> uDx uDy uy. rewrite inG2E -!(@mem_imset_eq _ _ val) // -imset_comp eq_Y /=.
+    { move=> uDx uDy uy. rewrite inG2E -!(@mem_imset _ _ val) // -imset_comp eq_Y /=.
       by rewrite !inE uDx sgP. }
     have inG2X u : u != x -> u != y -> u -- x -> inG2 u \in X.
-    { move=> uDx uDy uy. rewrite inG2E -!(@mem_imset_eq _ _ val) // -imset_comp eq_X /=.
+    { move=> uDx uDy uy. rewrite inG2E -!(@mem_imset _ _ val) // -imset_comp eq_X /=.
       by rewrite !inE uDy sgP. }
     have dhom_bwd : is_dhom bwd. 
     { move => u v uv; rewrite /bwd. 
       have [?|uDy] := eqVneq u y; first subst u. 
         have [E|vDy] := eqVneq v y; first by rewrite E sgP in uv.
         have [?|vDx] := eqVneq v x; first by rewrite /edge_rel/= !inE eqxx.
-        by rewrite /edge_rel/= inE mem_imset_eq // inE inG2Y 1?sgP.
+        by rewrite /edge_rel/= inE mem_imset // inE inG2Y 1?sgP.
       have [?|uDx] := eqVneq u x;first subst u. 
         have [E|vDx] := eqVneq v x; first by rewrite E sgP in uv.
         have [?|vDy] := eqVneq v y; first by rewrite /edge_rel/= !inE eqxx.
         by rewrite /edge_rel/= /edge_rel/= inE inG2X 1?sgP.
       have [?|vDy] := eqVneq v y; first subst v. 
-        by rewrite /edge_rel/= inE mem_imset_eq // inE inG2Y.
+        by rewrite /edge_rel/= inE mem_imset // inE inG2Y.
       have [?|vDx] := eqVneq v x; first subst v.
         by rewrite /edge_rel/= /edge_rel/= inE inG2X.
       rewrite /edge_rel /= /edge_rel/= /edge_rel/=. 

--- a/theories/wpgt.v
+++ b/theories/wpgt.v
@@ -710,7 +710,7 @@ have sum_j i : \sum_(j | i != j) #|K i :&: S j| >= a * w.
   under eq_bigr => x x_Ki; first rewrite muln1 -(cutS x); first over. 
   move: x x_Ki; apply/subsetP. by move: (maxK i); rewrite !inE -andbA => /and3P[]. (* fixme *)
   rewrite exchange_big/=. under eq_bigr => j do rewrite sum_cardI.
-  by rewrite [X in _ <= X]big_uncond // => j /negPn/eqP<-. }
+  by rewrite [X in _ <= X]big_rmcond // => j /negPn/eqP<-. }
 move => i j iDj; apply: contraTeq (sum_j i).
 rewrite eqn_leq negb_and le_KiSj -leqNgt leqn0 /= -ltnNge => /eqP KiSj0.
 rewrite (bigD1 j) //= KiSj0 add0n.


### PR DESCRIPTION
- remove deprecated mem_imset_eq and big_uncond
- use #[export] for instances
- update CI scripts