### PR TITLE
run cron CI once peer week

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -2,7 +2,7 @@ name: Docker CI
 
 on:
   schedule:
-    - cron: '25 5 * * *'
+    - cron: '25 5 * * 5'
   push:
     branches:
       - master

--- a/meta.yml
+++ b/meta.yml
@@ -77,7 +77,7 @@ tested_coq_opam_versions:
 - version: '1.13.0-coq-8.14'
   repo: 'mathcomp/mathcomp'
 
-ci_cron_schedule: '25 5 * * *'
+ci_cron_schedule: '25 5 * * 5'
 
 dependencies:
 - opam:


### PR DESCRIPTION
Since `coq-elpi.dev` undergoes a lot of code churn via Coq, and this library is not changing as rapidly, I think it makes sense to only do cron CI once per week (as opposed to the current per day). This should still allow catching incompatibility with MathComp dev.

Please let me know if you disagree @chdoc, otherwise I'll merge later this week.