### PR TITLE
enable mathcomp dev Docker ci

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         image:
+          - 'mathcomp/mathcomp-dev:coq-dev'
           - 'mathcomp/mathcomp:2.0.0-coq-8.17'
           - 'mathcomp/mathcomp:2.0.0-coq-8.16'
       fail-fast: false

--- a/meta.yml
+++ b/meta.yml
@@ -68,6 +68,8 @@ supported_coq_versions:
   opam: '{>= "8.16"}'
 
 tested_coq_opam_versions:
+- version: 'coq-dev'
+  repo: 'mathcomp/mathcomp-dev'
 - version: '2.0.0-coq-8.17'
   repo: 'mathcomp/mathcomp'
 - version: '2.0.0-coq-8.16'


### PR DESCRIPTION
This is to restore testing with MathComp master with Docker-based CI.