### PR TITLE
Adapt to mathc-omp/math-comp#1240

### DIFF
--- a/theories/core/edone.v
+++ b/theories/core/edone.v
@@ -24,7 +24,6 @@ Ltac done := trivial; hnf in |- *; intros;
       | apply/andP;split
       | rewrite ?andbT ?andbF ?orbT ?orbF ]
     )
-    | case not_locked_false_eq_true; assumption
     | match goal with
         | H:~ _ |- _ => solve [ case H; trivial ]
       end


### PR DESCRIPTION
We discovered this line is now useless during CUDW. Probably not any noticeable speed-up (haven't measured) but still good as a cleanup.

Successfully tested on https://github.com/math-comp/math-comp/pull/1246