### PR TITLE
Adapt to https://github.com/math-comp/math-comp/pull/1456/

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -18,8 +18,9 @@ jobs:
       matrix:
         image:
           - 'mathcomp/mathcomp-dev:rocq-prover-dev'
-          - 'mathcomp/mathcomp:2.4.0-rocq-prover-9.0'
-          - 'mathcomp/mathcomp:2.2.0-coq-8.20'
+          - 'mathcomp/mathcomp:2.5.0-coq-8.20'
+          - 'mathcomp/mathcomp:2.5.0-rocq-prover-9.0'
+          - 'mathcomp/mathcomp:2.5.0-rocq-prover-9.1'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ axiomatization of graph isomorphism).
 - License: [CeCILL-B](LICENSE)
 - Compatible Coq versions: 8.19 or later
 - Additional dependencies:
-  - MathComp's [SSReflect library](https://math-comp.github.io), version 2.1.0 or later
+  - MathComp's [SSReflect library](https://math-comp.github.io), version 2.5.0 or later
   - MathComp's [Algebra library](https://math-comp.github.io)
   - MathComp's [finmap library](https://github.com/math-comp/finmap)
   - MathComp's [Algebra tactics](https://github.com/math-comp/algebra-tactics)

--- a/coq-graph-theory-planar.opam
+++ b/coq-graph-theory-planar.opam
@@ -17,7 +17,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "3.5"}
   "coq" {>= "8.19"}
-  "coq-mathcomp-ssreflect" {>= "2.1.0"}
+  "coq-mathcomp-ssreflect" {>= "2.5.0"}
   "coq-mathcomp-algebra-tactics"
   "coq-graph-theory" {= version}
   "coq-fourcolor"

--- a/coq-graph-theory-planar.opam
+++ b/coq-graph-theory-planar.opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "3.5"}
   "coq" {>= "8.19"}
   "coq-mathcomp-ssreflect" {>= "2.5.0"}
-  "coq-mathcomp-algebra-tactics"
+  ("coq-mathcomp-algebra" {>= "2.6.0"} | "coq-mathcomp-algebra-tactics")
   "coq-graph-theory" {= version}
   "coq-fourcolor"
 ]

--- a/coq-graph-theory.opam
+++ b/coq-graph-theory.opam
@@ -17,7 +17,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "3.5"}
   "coq" {>= "8.19"}
-  "coq-mathcomp-ssreflect" {>= "2.1.0"}
+  "coq-mathcomp-ssreflect" {>= "2.5.0"}
   "coq-mathcomp-algebra" 
   "coq-mathcomp-finmap" 
   "coq-hierarchy-builder" {>= "1.5.0"}

--- a/meta.yml
+++ b/meta.yml
@@ -70,9 +70,11 @@ supported_coq_versions:
 tested_coq_opam_versions:
 - version: 'rocq-prover-dev'
   repo: 'mathcomp/mathcomp-dev'
-- version: '2.2.0-coq-8.20'
+- version: '2.5.0-coq-8.20'
   repo: 'mathcomp/mathcomp'
-- version: '2.2.0-coq-8.19'
+- version: '2.5.0-rocq-prover-9.0'
+  repo: 'mathcomp/mathcomp'
+- version: '2.5.0-rocq-prover-9.1'
   repo: 'mathcomp/mathcomp'
 
 ci_cron_schedule: '25 5 * * 5'
@@ -80,8 +82,8 @@ ci_cron_schedule: '25 5 * * 5'
 dependencies:
 - opam:
     name: coq-mathcomp-ssreflect
-    version: '{>= "2.1.0"}'
-  description: MathComp's [SSReflect library](https://math-comp.github.io), version 2.1.0 or later
+    version: '{>= "2.5.0"}'
+  description: MathComp's [SSReflect library](https://math-comp.github.io), version 2.5.0 or later
 - opam:
     name: coq-mathcomp-algebra
   description: MathComp's [Algebra library](https://math-comp.github.io)

--- a/theories/core/arc.v
+++ b/theories/core/arc.v
@@ -1,5 +1,5 @@
 From Coq Require Import Setoid Morphisms.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.

--- a/theories/core/bij.v
+++ b/theories/core/bij.v
@@ -1,6 +1,6 @@
 From Coq Require Import Setoid CMorphisms.
 From Coq Require Relation_Definitions.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone preliminaries.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)

--- a/theories/core/bounded.v
+++ b/theories/core/bounded.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.

--- a/theories/core/checkpoint.v
+++ b/theories/core/checkpoint.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone preliminaries digraph.
 From GraphTheory Require Import sgraph connectivity.
 

--- a/theories/core/coloring.v
+++ b/theories/core/coloring.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import preliminaries bij digraph.
 From GraphTheory Require Import sgraph dom partition.
 

--- a/theories/core/completeness.v
+++ b/theories/core/completeness.v
@@ -1,5 +1,5 @@
 From Coq Require Import Setoid Morphisms Wf_nat.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone preliminaries bij.
 From GraphTheory Require Import setoid_bigop structures mgraph pttdom mgraph2.
 From GraphTheory Require Import rewriting reduction open_confluence transfer.

--- a/theories/core/connectivity.v
+++ b/theories/core/connectivity.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone preliminaries digraph mgraph sgraph set_tac.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)

--- a/theories/core/cp_minor.v
+++ b/theories/core/cp_minor.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 
 From GraphTheory Require Import edone preliminaries digraph sgraph minor.
 From GraphTheory Require Import checkpoint connectivity excluded set_tac.

--- a/theories/core/digraph.v
+++ b/theories/core/digraph.v
@@ -1,7 +1,7 @@
 From HB Require Import structures.
 From Coq Require Import Setoid CMorphisms.
 From Coq Require Relation_Definitions.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone preliminaries bij.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)

--- a/theories/core/dom.v
+++ b/theories/core/dom.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import preliminaries digraph sgraph.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)

--- a/theories/core/equiv.v
+++ b/theories/core/equiv.v
@@ -1,5 +1,5 @@
 From Coq Require Import RelationClasses Setoid Morphisms List.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import preliminaries bij finite_quotient.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)

--- a/theories/core/excluded.v
+++ b/theories/core/excluded.v
@@ -1,5 +1,5 @@
 From Coq Require Import Setoid Morphisms.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 (* Note: ssrbool is empty and shadows Coq.ssr.ssrbool, use Coq.ssrbool for "Find" *)
 
 From GraphTheory Require Import edone preliminaries set_tac digraph.

--- a/theories/core/extraction_def.v
+++ b/theories/core/extraction_def.v
@@ -1,6 +1,6 @@
 From Coq Require Import RelationClasses Morphisms Setoid Lia.
 
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 
 From GraphTheory Require Import edone finite_quotient preliminaries.
 From GraphTheory Require Import digraph sgraph minor checkpoint cp_minor. 

--- a/theories/core/extraction_iso.v
+++ b/theories/core/extraction_iso.v
@@ -1,6 +1,6 @@
 From Coq Require Import RelationClasses Morphisms Setoid.
 
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 
 From GraphTheory Require Import edone finite_quotient preliminaries.
 From GraphTheory Require Import bij set_tac digraph sgraph minor checkpoint.

--- a/theories/core/extraction_top.v
+++ b/theories/core/extraction_top.v
@@ -1,6 +1,6 @@
 From Coq Require Import RelationClasses Morphisms Setoid.
 
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 
 From GraphTheory Require Import edone finite_quotient preliminaries set_tac.
 From GraphTheory Require Import digraph sgraph treewidth minor checkpoint.

--- a/theories/core/finite_quotient.v
+++ b/theories/core/finite_quotient.v
@@ -1,6 +1,6 @@
 From HB Require Import structures.
 From Coq Require Import Setoid CMorphisms.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import preliminaries bij.
 Local Open Scope quotient_scope.
 

--- a/theories/core/finmap_plus.v
+++ b/theories/core/finmap_plus.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From mathcomp Require Export finmap.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)

--- a/theories/core/helly.v
+++ b/theories/core/helly.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone preliminaries digraph sgraph set_tac.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)

--- a/theories/core/mgraph.v
+++ b/theories/core/mgraph.v
@@ -1,6 +1,6 @@
 From Coq Require Import Morphisms RelationClasses.
 From Coq Require CMorphisms CRelationClasses. (* To be used explicitly *)
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone finite_quotient preliminaries bij.
 From GraphTheory Require Import equiv digraph setoid_bigop structures.
 

--- a/theories/core/mgraph2.v
+++ b/theories/core/mgraph2.v
@@ -1,6 +1,6 @@
 From HB Require Import structures.
 From Coq Require Import Setoid Morphisms.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone finite_quotient preliminaries bij equiv.
 From GraphTheory Require Import setoid_bigop structures pttdom mgraph ptt.
 

--- a/theories/core/mgraph2_tw2.v
+++ b/theories/core/mgraph2_tw2.v
@@ -1,5 +1,5 @@
 From Coq Require Import RelationClasses Setoid.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone set_tac finite_quotient preliminaries.
 From GraphTheory Require Import digraph sgraph treewidth minor equiv setoid_bigop.
 From GraphTheory Require Import structures mgraph pttdom ptt mgraph2 skeleton.

--- a/theories/core/minor.v
+++ b/theories/core/minor.v
@@ -1,6 +1,6 @@
 From Coq Require Import RelationClasses.
 
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone preliminaries digraph.
 From GraphTheory Require Import sgraph treewidth set_tac.
 

--- a/theories/core/open_confluence.v
+++ b/theories/core/open_confluence.v
@@ -1,6 +1,6 @@
 From HB Require Import structures.
 From Coq Require Import Relation_Definitions Morphisms RelationClasses.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 
 From GraphTheory Require Import edone finite_quotient preliminaries bij equiv.
 From GraphTheory Require Import setoid_bigop structures pttdom rewriting.

--- a/theories/core/partition.v
+++ b/theories/core/partition.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.

--- a/theories/core/preliminaries.v
+++ b/theories/core/preliminaries.v
@@ -1,5 +1,5 @@
 From Coq Require Import Setoid Morphisms.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)

--- a/theories/core/ptt.v
+++ b/theories/core/ptt.v
@@ -1,6 +1,6 @@
 From HB Require Import structures.
 From Coq Require Import Setoid Morphisms.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone preliminaries setoid_bigop structures pttdom.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)

--- a/theories/core/pttdom.v
+++ b/theories/core/pttdom.v
@@ -1,6 +1,6 @@
 From HB Require Import structures.
 From Coq Require Import Setoid Morphisms.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone preliminaries setoid_bigop structures.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)

--- a/theories/core/reduction.v
+++ b/theories/core/reduction.v
@@ -1,6 +1,6 @@
 From HB Require Import structures.
 From Coq Require Import Setoid Morphisms.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone finite_quotient preliminaries bij equiv.
 From GraphTheory Require Import setoid_bigop structures pttdom mgraph mgraph2 rewriting.
 

--- a/theories/core/rewriting.v
+++ b/theories/core/rewriting.v
@@ -1,5 +1,5 @@
 From Coq Require Import Setoid Morphisms.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import setoid_bigop structures pttdom mgraph mgraph2.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)

--- a/theories/core/set_tac.v
+++ b/theories/core/set_tac.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 
 From GraphTheory Require Import preliminaries.
 

--- a/theories/core/setoid_bigop.v
+++ b/theories/core/setoid_bigop.v
@@ -1,6 +1,6 @@
 From HB Require Import structures.
 From Coq Require Import RelationClasses Morphisms Relation_Definitions.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)
 Set Implicit Arguments.

--- a/theories/core/sgraph.v
+++ b/theories/core/sgraph.v
@@ -1,5 +1,5 @@
 From Coq Require Import Setoid CMorphisms.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone preliminaries bij digraph.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)

--- a/theories/core/skeleton.v
+++ b/theories/core/skeleton.v
@@ -1,6 +1,6 @@
 From Coq Require Import Setoid Morphisms.
 
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone finite_quotient bij preliminaries.
 From GraphTheory Require Import digraph sgraph treewidth minor checkpoint.
 From GraphTheory Require Import setoid_bigop structures mgraph mgraph2.

--- a/theories/core/smerge.v
+++ b/theories/core/smerge.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone preliminaries digraph sgraph.
 From GraphTheory Require Import connectivity minor treewidth arc set_tac.
 

--- a/theories/core/structures.v
+++ b/theories/core/structures.v
@@ -1,6 +1,6 @@
 From HB Require Import structures.
 From Coq Require Import RelationClasses Morphisms Relation_Definitions.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone preliminaries setoid_bigop bij.
 
 Set SsrOldRewriteGoalsOrder.  (* change Set to Unset when porting the file, then remove the line when requiring MathComp >= 2.6 *)

--- a/theories/core/transfer.v
+++ b/theories/core/transfer.v
@@ -1,5 +1,5 @@
 From Coq Require Import Relation_Definitions Morphisms RelationClasses.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 
 From GraphTheory Require Import edone finite_quotient preliminaries bij equiv.
 From GraphTheory Require Import setoid_bigop structures pttdom mgraph mgraph2.

--- a/theories/core/treewidth.v
+++ b/theories/core/treewidth.v
@@ -1,6 +1,6 @@
 From Coq Require Import RelationClasses.
 
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone preliminaries digraph sgraph.
 From GraphTheory Require Import connectivity set_tac.
 

--- a/theories/core/wpgt.v
+++ b/theories/core/wpgt.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import preliminaries bij digraph sgraph.
 From GraphTheory Require Import dom partition coloring.
 

--- a/theories/planar/K4plane.v
+++ b/theories/planar/K4plane.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From fourcolor Require Import hypermap geometry.
 From GraphTheory Require Import preliminaries digraph sgraph.
 From GraphTheory Require Import hmap_ops embedding.

--- a/theories/planar/embedding.v
+++ b/theories/planar/embedding.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From fourcolor Require Import hypermap geometry color coloring walkup combinatorial4ct cfmap.
 From GraphTheory Require Import edone preliminaries bij digraph sgraph.
 From GraphTheory Require Import connectivity minor hmap_ops smerge hcycle arc.

--- a/theories/planar/hcycle.v
+++ b/theories/planar/hcycle.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 
 From GraphTheory Require Import edone preliminaries digraph sgraph.
 From fourcolor Require Import hypermap geometry jordan color coloring combinatorial4ct.

--- a/theories/planar/hmap_ops.v
+++ b/theories/planar/hmap_ops.v
@@ -1,4 +1,4 @@
-From mathcomp Require Import all_ssreflect ring.
+From mathcomp Require Import all_boot ring.
 From GraphTheory Require Import edone preliminaries bij.
 From fourcolor Require Import hypermap geometry cfmap jordan color coloring combinatorial4ct.
 From fourcolor Require Import walkup.

--- a/theories/planar/wagner.v
+++ b/theories/planar/wagner.v
@@ -1,5 +1,5 @@
 From HB Require Import structures.
-From mathcomp Require Import all_ssreflect.
+From mathcomp Require Import all_boot.
 From GraphTheory Require Import edone preliminaries bij digraph.
 From GraphTheory Require Import sgraph connectivity minor excluded.
 From fourcolor Require Import hypermap geometry walkup color coloring combinatorial4ct.


### PR DESCRIPTION
The upstream PR removes the dependency to mathcomp-algebra-tactics, that was implicitly drawing mathcomp-ssreflect.